### PR TITLE
Show Toggle indicator arrows and titles for Statistics panels

### DIFF
--- a/includes/log/all-browsers.php
+++ b/includes/log/all-browsers.php
@@ -35,8 +35,12 @@ $rangeenddate   = $WP_Statistics->real_current_date( 'Y-m-d', '-0', $rangeend_ut
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Browsers', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Browsers', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             jQuery(function () {
@@ -123,8 +127,12 @@ $rangeenddate   = $WP_Statistics->real_current_date( 'Y-m-d', '-0', $rangeend_ut
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Platform', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Platform', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             jQuery(function () {
@@ -258,8 +266,12 @@ $rangeenddate   = $WP_Statistics->real_current_date( 'Y-m-d', '-0', $rangeend_ut
 <?php function BrowserVersionStats( $Browser, $rangestartdate = null, $rangeenddate = null ) {
 	$Browser_tag = strtolower( preg_replace( '/[^a-zA-Z]/', '', $Browser ) ); ?>
     <div class="postbox">
-        <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-        <h3 class="hndle"><span><?php echo sprintf( __( '%s Version', 'wp_statistics' ), $Browser ); ?></span></h3>
+        <?php $paneltitle = sprintf( __( '%s Version', 'wp_statistics' ), $Browser ); ?>
+        <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+            <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+            <span class="toggle-indicator" aria-hidden="true"></span>
+        </button>
+        <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
         <div class="inside">
             <script type="text/javascript">
                 jQuery(function () {

--- a/includes/log/authors.php
+++ b/includes/log/authors.php
@@ -80,8 +80,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Author Statistics Chart', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Author Statistics Chart', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var visit_chart;
@@ -219,8 +223,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Author Statistics Summary', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Author Statistics Summary', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="summary-stats">
                             <tbody>
@@ -264,8 +272,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Author Posts Sorted by Hits', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Author Posts Sorted by Hits', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="post-stats">
                             <tbody>

--- a/includes/log/categories.php
+++ b/includes/log/categories.php
@@ -64,8 +64,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Category Statistics Chart', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Category Statistics Chart', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var visit_chart;
@@ -203,8 +207,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Category Statistics Summary', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Category Statistics Summary', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="summary-stats">
                             <tbody>
@@ -248,8 +256,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Category Posts Sorted by Hits', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Category Posts Sorted by Hits', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="post-stats">
                             <tbody>

--- a/includes/log/exclusions.php
+++ b/includes/log/exclusions.php
@@ -154,8 +154,12 @@ if ( $total_stats == 1 ) {
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Exclusions Statistical Chart', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Exclusions Statistical Chart', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var visit_chart;
@@ -278,8 +282,12 @@ if ( $total_stats == 1 ) {
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Hits Statistics Summary', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Hits Statistics Summary', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="summary-stats">
                             <tbody>

--- a/includes/log/hit-statistics.php
+++ b/includes/log/hit-statistics.php
@@ -32,8 +32,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Hits Statistics Chart', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Hits Statistics Chart', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var visit_chart;
@@ -171,8 +175,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Hits Statistics Summary', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Hits Statistics Summary', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="summary-stats">
                             <tbody>

--- a/includes/log/last-search.php
+++ b/includes/log/last-search.php
@@ -57,8 +57,12 @@ $total = $search_result[ $referred ];
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Latest Search Word Statistics', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Latest Search Word Statistics', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <div class='log-latest'>
 							<?php

--- a/includes/log/last-visitor.php
+++ b/includes/log/last-visitor.php
@@ -79,12 +79,15 @@ if ( $_get != '%' ) {
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Recent Visitor Statistics', 'wp_statistics' );
-							if ( $_get != '%' ) {
-								echo ' [' . __( 'Filtered by', 'wp_statistics' ) . ': ' . $title . ']';
-							} ?></span></h3>
-
+                    <?php $paneltitle = __( 'Recent Visitor Statistics', 'wp_statistics' );
+                        if ( $_get != '%' ) {
+                            $paneltitle = $paneltitle . ' [' . __( 'Filtered by', 'wp_statistics' ) . ': ' . $title . ']';
+                        } ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
 						<?php
 						// Instantiate pagination object with appropriate arguments

--- a/includes/log/online.php
+++ b/includes/log/online.php
@@ -13,8 +13,12 @@
             <div class="meta-box-sortables">
 
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Online Users', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Online Users', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
 						<?php
 						$ISOCountryCode = $WP_Statistics->get_country_codes();

--- a/includes/log/page-statistics.php
+++ b/includes/log/page-statistics.php
@@ -56,8 +56,12 @@ if ( array_key_exists( 'rangeend', $_GET ) ) {
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Page Trend', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle = __( 'Page Trend', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
 						<?php include_once( dirname( __FILE__ ) . '/widgets/page.php' );
 						wp_statistics_generate_page_postbox_content( $pageuri, $pageid, $daysToDisplay, null, $rangestart, $rangeend ); ?>

--- a/includes/log/search-statistics.php
+++ b/includes/log/search-statistics.php
@@ -34,9 +34,12 @@ $daysInThePast = round( ( time() - $rangeend_utime ) / 86400, 0 );
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Search Engine Referral Statistics', 'wp_statistics' ); ?></span>
-                    </h3>
+                    <?php $paneltitle = __( 'Search Engine Referral Statistics', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></span></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var visit_chart;

--- a/includes/log/tags.php
+++ b/includes/log/tags.php
@@ -85,8 +85,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Tag Statistics Chart', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Tag Statistics Chart', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var visit_chart;
@@ -224,8 +228,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Tag Statistics Summary', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Tag Statistics Summary', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="summary-stats">
                             <tbody>
@@ -269,8 +277,12 @@
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Tag Posts Sorted by Hits', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Tag Posts Sorted by Hits', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
                         <table width="auto" class="widefat table-stats" id="post-stats">
                             <tbody>

--- a/includes/log/top-countries.php
+++ b/includes/log/top-countries.php
@@ -32,8 +32,12 @@ list( $daysToDisplay, $rangestart_utime, $rangeend_utime ) = wp_statistics_date_
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Top Countries', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Top Countries', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
                         <table class="widefat table-stats" id="last-referrer" style="width: 100%;">
                             <tr>

--- a/includes/log/top-pages.php
+++ b/includes/log/top-pages.php
@@ -36,8 +36,12 @@ list( $total, $uris ) = wp_statistics_get_top_pages( $WP_Statistics->Real_Curren
             <div class="meta-box-sortables">
 
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Top 5 Pages Trends', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Top 5 Pages Trends', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
                         <script type="text/javascript">
                             var pages_jqchart;
@@ -166,8 +170,12 @@ list( $total, $uris ) = wp_statistics_get_top_pages( $WP_Statistics->Real_Curren
                 </div>
 
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Top Pages', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Top Pages', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
 						<?php
 						if ( $total > 0 ) {

--- a/includes/log/top-referring.php
+++ b/includes/log/top-referring.php
@@ -99,13 +99,16 @@ if ( $referr ) {
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-					<?php if ( $referr ) { ?>
-                        <h3 class="hndle"><span><?php _e( 'Referring sites from', 'wp_statistics' ); ?>
-                                : <?php echo $WP_Statistics->html_sanitize_referrer( $referr ); ?></span></h3>
-					<?php } else { ?>
-                        <h3 class="hndle"><span><?php _e( 'Top Referring Sites', 'wp_statistics' ); ?></span></h3>
-					<?php } ?>
+                    <?php if ( $referr ) {
+                        $paneltitle = sprintf( __( 'Referring sites from: %s', 'wp_statistics' ), $WP_Statistics->html_sanitize_referrer( $referr ) );
+                    } else {
+                        $paneltitle = __( 'Top Referring Sites', 'wp_statistics' );
+                    }; ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
 						<?php
 						echo "<div class='log-latest'>";

--- a/includes/log/top-visitors.php
+++ b/includes/log/top-visitors.php
@@ -38,8 +38,12 @@ include_once( dirname( __FILE__ ) . '/widgets/top.visitors.php' );
         <div class="metabox-holder">
             <div class="meta-box-sortables">
                 <div class="postbox">
-                    <div class="handlediv" title="<?php _e( 'Click to toggle', 'wp_statistics' ); ?>"><br/></div>
-                    <h3 class="hndle"><span><?php _e( 'Top Visitors', 'wp_statistics' ); ?></span></h3>
+                    <?php $paneltitle =  __( 'Top Visitors', 'wp_statistics' ); ?>
+                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                        <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
+                        <span class="toggle-indicator" aria-hidden="true"></span>
+                    </button>
+                    <h2 class="hndle"><span><?php echo $paneltitle; ?></h2>
                     <div class="inside">
 
 						<?php wp_statistics_generate_top_visitors_postbox_content( $ISOCountryCode, $statsdate, 100, false ); ?>


### PR DESCRIPTION
Solves issue https://github.com/wp-statistics/wp-statistics/issues/8

As explained in the issue description, this changes followed the same code pattern of WordPress dashboard panels rendered code, adding the following:
- screen reader text
- toggle indicator arrow
- key navigation
- UI and Translation strings consistent with core
