### PR TITLE
Add title and screen reader text to metabox More and Reload buttons

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -161,8 +161,8 @@ function wp_statistics_dashboard_inline_javascript() {
 
 	$loading_img = '<div style="width: 100%; text-align: center;"><img src=" ' . plugins_url( 'wp-statistics/assets/images/' ) . 'ajax-loading.gif" alt="' . __( 'Reloading...', 'wp_statistics' ) . '"></div>';
 
-	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '</button><button class="handlediv button-link wps-more" type="button" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '</button>';
-	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '</button>';
+	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" title="' . __( 'More Details', 'wp_statistics' ) . '" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
+	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
 
 	$admin_url = get_admin_url() . "admin.php?page=";
 

--- a/editor.php
+++ b/editor.php
@@ -96,8 +96,8 @@ function wp_statistics_editor_inline_javascript() {
 
 	$loading_img = '<div style="width: 100%; text-align: center;"><img src=" ' . plugins_url( 'wp-statistics/assets/images/' ) . 'ajax-loading.gif" alt="' . __( 'Reloading...', 'wp_statistics' ) . '"></div>';
 
-	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '</button><button class="handlediv button-link wps-more" type="button" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '</button>';
-	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '</button>';
+	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" title="' . __( 'More Details', 'wp_statistics' ) . '" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
+	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
 
 	$admin_url = get_admin_url() . "/admin.php?page=";
 

--- a/includes/log/log.php
+++ b/includes/log/log.php
@@ -43,8 +43,8 @@ function wp_statistics_generate_overview_postbox_contents( $post, $args ) {
     </div>
 </div>
 <?php
-$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '</button><button class="handlediv button-link wps-more" type="button" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '</button>';
-$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '</button>';
+$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" title="' . __( 'More Details', 'wp_statistics' ) . '" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
+$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
 
 $admin_url = get_admin_url() . "admin.php?page=";
 


### PR DESCRIPTION
Adds:
- screen-reader-text to metabox Reload and More button
- title attribute to metabox Reload and More button

Adding the titles keeps it consistent with the previously existent Toggle buttons, despite WP core doesn't use any title attributes in metaboxes buttons.
If you choose not tu use `title` button attribute, it should also be deleted from the several metaboxes code `<button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">` added in the commit https://github.com/wp-statistics/wp-statistics/commit/23724efb571c75e21d9704558407bf93439da94b