### PR TITLE
Widget metabox buttons consistent with WP core

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -161,8 +161,8 @@ function wp_statistics_dashboard_inline_javascript() {
 
 	$loading_img = '<div style="width: 100%; text-align: center;"><img src=" ' . plugins_url( 'wp-statistics/assets/images/' ) . 'ajax-loading.gif" alt="' . __( 'Reloading...', 'wp_statistics' ) . '"></div>';
 
-	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" title="' . __( 'More Details', 'wp_statistics' ) . '" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
-	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
+	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
+	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
 
 	$admin_url = get_admin_url() . "admin.php?page=";
 

--- a/editor.php
+++ b/editor.php
@@ -96,8 +96,8 @@ function wp_statistics_editor_inline_javascript() {
 
 	$loading_img = '<div style="width: 100%; text-align: center;"><img src=" ' . plugins_url( 'wp-statistics/assets/images/' ) . 'ajax-loading.gif" alt="' . __( 'Reloading...', 'wp_statistics' ) . '"></div>';
 
-	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" title="' . __( 'More Details', 'wp_statistics' ) . '" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
-	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
+	$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
+	$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
 
 	$admin_url = get_admin_url() . "/admin.php?page=";
 

--- a/includes/log/all-browsers.php
+++ b/includes/log/all-browsers.php
@@ -36,7 +36,7 @@ $rangeenddate   = $WP_Statistics->real_current_date( 'Y-m-d', '-0', $rangeend_ut
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Browsers', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -128,7 +128,7 @@ $rangeenddate   = $WP_Statistics->real_current_date( 'Y-m-d', '-0', $rangeend_ut
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Platform', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -267,7 +267,7 @@ $rangeenddate   = $WP_Statistics->real_current_date( 'Y-m-d', '-0', $rangeend_ut
 	$Browser_tag = strtolower( preg_replace( '/[^a-zA-Z]/', '', $Browser ) ); ?>
     <div class="postbox">
         <?php $paneltitle = sprintf( __( '%s Version', 'wp_statistics' ), $Browser ); ?>
-        <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+        <button class="handlediv" type="button" aria-expanded="true">
             <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
             <span class="toggle-indicator" aria-hidden="true"></span>
         </button>

--- a/includes/log/authors.php
+++ b/includes/log/authors.php
@@ -81,7 +81,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Author Statistics Chart', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -224,7 +224,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Author Statistics Summary', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -273,7 +273,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Author Posts Sorted by Hits', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/categories.php
+++ b/includes/log/categories.php
@@ -65,7 +65,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Category Statistics Chart', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -208,7 +208,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Category Statistics Summary', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -257,7 +257,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Category Posts Sorted by Hits', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/exclusions.php
+++ b/includes/log/exclusions.php
@@ -155,7 +155,7 @@ if ( $total_stats == 1 ) {
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Exclusions Statistical Chart', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -283,7 +283,7 @@ if ( $total_stats == 1 ) {
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Hits Statistics Summary', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/hit-statistics.php
+++ b/includes/log/hit-statistics.php
@@ -33,7 +33,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Hits Statistics Chart', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -176,7 +176,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Hits Statistics Summary', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/last-search.php
+++ b/includes/log/last-search.php
@@ -58,7 +58,7 @@ $total = $search_result[ $referred ];
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Latest Search Word Statistics', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/last-visitor.php
+++ b/includes/log/last-visitor.php
@@ -83,7 +83,7 @@ if ( $_get != '%' ) {
                         if ( $_get != '%' ) {
                             $paneltitle = $paneltitle . ' [' . __( 'Filtered by', 'wp_statistics' ) . ': ' . $title . ']';
                         } ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/log.php
+++ b/includes/log/log.php
@@ -43,8 +43,8 @@ function wp_statistics_generate_overview_postbox_contents( $post, $args ) {
     </div>
 </div>
 <?php
-$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" title="' . __( 'More Details', 'wp_statistics' ) . '" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
-$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" title="' . __( 'Reload', 'wp_statistics' ) . '" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
+$new_buttons = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button><button class="handlediv button-link wps-more" type="button" id="{{moreid}}">' . wp_statistics_icons( 'dashicons-migrate' ) . '<span class="screen-reader-text">' . __( 'More Details', 'wp_statistics' ) . '</span></button>';
+$new_button  = '</button><button class="handlediv button-link wps-refresh" type="button" id="{{refreshid}}">' . wp_statistics_icons( 'dashicons-update' ) . '<span class="screen-reader-text">' . __( 'Reload', 'wp_statistics' ) . '</span></button>';
 
 $admin_url = get_admin_url() . "admin.php?page=";
 

--- a/includes/log/online.php
+++ b/includes/log/online.php
@@ -14,7 +14,7 @@
 
                 <div class="postbox">
                     <?php $paneltitle = __( 'Online Users', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/page-statistics.php
+++ b/includes/log/page-statistics.php
@@ -57,7 +57,7 @@ if ( array_key_exists( 'rangeend', $_GET ) ) {
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Page Trend', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/search-statistics.php
+++ b/includes/log/search-statistics.php
@@ -35,7 +35,7 @@ $daysInThePast = round( ( time() - $rangeend_utime ) / 86400, 0 );
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle = __( 'Search Engine Referral Statistics', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/tags.php
+++ b/includes/log/tags.php
@@ -86,7 +86,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Tag Statistics Chart', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -229,7 +229,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Tag Statistics Summary', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -278,7 +278,7 @@
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Tag Posts Sorted by Hits', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/top-countries.php
+++ b/includes/log/top-countries.php
@@ -33,7 +33,7 @@ list( $daysToDisplay, $rangestart_utime, $rangeend_utime ) = wp_statistics_date_
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Top Countries', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/top-pages.php
+++ b/includes/log/top-pages.php
@@ -37,7 +37,7 @@ list( $total, $uris ) = wp_statistics_get_top_pages( $WP_Statistics->Real_Curren
 
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Top 5 Pages Trends', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>
@@ -171,7 +171,7 @@ list( $total, $uris ) = wp_statistics_get_top_pages( $WP_Statistics->Real_Curren
 
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Top Pages', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/top-referring.php
+++ b/includes/log/top-referring.php
@@ -104,7 +104,7 @@ if ( $referr ) {
                     } else {
                         $paneltitle = __( 'Top Referring Sites', 'wp_statistics' );
                     }; ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/includes/log/top-visitors.php
+++ b/includes/log/top-visitors.php
@@ -39,7 +39,7 @@ include_once( dirname( __FILE__ ) . '/widgets/top.visitors.php' );
             <div class="meta-box-sortables">
                 <div class="postbox">
                     <?php $paneltitle =  __( 'Top Visitors', 'wp_statistics' ); ?>
-                    <button class="handlediv" type="button" title="<?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?>">
+                    <button class="handlediv" type="button" aria-expanded="true">
                         <span class="screen-reader-text"><?php printf( __( 'Toggle panel: %s', 'wp_statistics' ), $paneltitle ); ?></span>
                         <span class="toggle-indicator" aria-hidden="true"></span>
                     </button>

--- a/readme.txt
+++ b/readme.txt
@@ -289,7 +289,10 @@ This is a security fix, please update immediately.
 == Changelog ==
 = 12.0.11 =
 * Fixed: links issue in the last visitors page.
+* Fixed: i18n issues (hardcoded strings, missing or incorrect textdomains).
 * Updated: admin CSS style. set `with` for Hits column in posts/pages list.
+* Updated: Improve consistency, best practices and correct typos in translation strings.
+* Updated: More, Reload and Toggle arrow buttons in metaboxes are consistent with WP core widget metaboxes, with screen-reader-text and key navigation.
 
 = 12.0.10 =
 * Release Date: July 24, 2017


### PR DESCRIPTION
Remove redundant and unnecessary `title` attributes from widget metabox buttons.
Add `aria-expanded="true"`

This makes the metaboxes consistent with [WP core metaboxes code](https://github.com/WordPress/WordPress/blob/master/wp-admin/includes/template.php#L1050)