### PR TITLE
Move metabox buttons CSS to log.css

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -11,11 +11,6 @@
     width: 52px;
 }
 
-.button-link.wps-more,
-.button-link.wps-refresh {
-    text-decoration: none !important;
-}
-
 .wp-statistics-plugins .widefat > * {
     float: left;
 }

--- a/assets/css/log.css
+++ b/assets/css/log.css
@@ -350,3 +350,8 @@
 .wp-statistics-sub-fullwidth {
     width: 100%;
 }
+
+.button-link.wps-more,
+.button-link.wps-refresh {
+    text-decoration: none !important;
+}


### PR DESCRIPTION
This fixes the issue mentioned [here](https://github.com/wp-statistics/wp-statistics/commit/6918fda7704838accedacf18043358e4272b0b25#commitcomment-24739044)