### PR TITLE
prevent referrer links to be relative to site url

### DIFF
--- a/includes/classes/statistics.class.php
+++ b/includes/classes/statistics.class.php
@@ -817,6 +817,6 @@ class WP_Statistics {
 			$eplises               = '';
 		}
 
-		return "<a href='{$html_referrer}'><div class='dashicons dashicons-admin-links'></div>{$html_referrer_limited}{$eplises}</a>";
+		return "<a href='//{$html_referrer}'><div class='dashicons dashicons-admin-links'></div>{$html_referrer_limited}{$eplises}</a>";
 	}
 }


### PR DESCRIPTION
I tried to add Schema based on referrer , But it is hard to add it based on referrer
Because we don't keep that in array
So we can just prevent the url to be relative at this moment
Most of the sites redirect http to https , if they support ssl