### PR TITLE
fix adminbar icon issue

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -123,3 +123,8 @@
 .column-wp-statistics {
     width: 52px;
 }
+
+#wpadminbar #wp-admin-bar-wp-statistic-menu .ab-icon:before {
+    content: '\f184';
+    top: 2px;
+}


### PR DESCRIPTION
fix adminbar icon issue
related support request:
https://wordpress.org/support/topic/why-is-the-icon-in-the-admin-bar-hidden/