### PR TITLE
Basic support for reverse proxys/CDNs/Docker/etc

### DIFF
--- a/includes/classes/class-wp-statistics.php
+++ b/includes/classes/class-wp-statistics.php
@@ -842,8 +842,14 @@ class WP_Statistics {
 			return $this->ip;
 		}
 
-		// By default we use the remote address the server has.
-		if ( array_key_exists( 'REMOTE_ADDR', $_SERVER ) ) {
+		// Try to detect originating IP
+		if ( array_key_exists( 'HTTP_X_FORWARDED_FOR', $_SERVER ) ) {
+			$temp_ip = $this->get_ip_value( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		} else if ( array_key_exists( 'HTTP_X_REAL_IP', $_SERVER ) ) {
+			$temp_ip = $this->get_ip_value( $_SERVER['HTTP_X_REAL_IP'] );
+		} else if ( array_key_exists( 'HTTP_CLIENT_IP', $_SERVER ) ) {
+			$temp_ip = $this->get_ip_value( $_SERVER['HTTP_CLIENT_IP'] );
+		} else if ( array_key_exists( 'REMOTE_ADDR', $_SERVER ) ) {
 			$temp_ip = $this->get_ip_value( $_SERVER['REMOTE_ADDR'] );
 		} else {
 			$temp_ip = '127.0.0.1';


### PR DESCRIPTION
In some situations REMOTE_ADDR might not point to the visitors address but the upstream proxy server. This leads to WP-Statistics only recording the same (server) IP over and over again. This change checks for the presence of typical headers proxys use to forward the originators IP and - if present - use these instead.

Note: Since these headers are not standardized this might still not work - making this section configurable would probably be a better idea in the long run