### PR TITLE
Opt-Out: Improve visibility

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -5,9 +5,11 @@
 
 .wp-statistics-opt-out {
     width: 100%;
-    background: #e2e2e2a3;
+    background: #e2e2e2aa;
+    border-top: 5px solid #333333;
     position: fixed;
     bottom: 0;
     text-align: center;
     padding: 8px 0;
+    z-index: 9999;
 }


### PR DESCRIPTION
The opt out bar is - depending on the theme used - unreadable due to other elements floating in front. z-index should fix this.
Additionally the text is hard to read if other text is displayed behind due to the high transparency, lowered here.
Lastly a nice bar to clearly separate the overlayed opt-out-bar from the rest of the content