### PR TITLE
Improved styling of opt-out message

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -5,11 +5,13 @@
 
 .wp-statistics-opt-out {
     width: 100%;
-    background: #e2e2e2aa;
+    background: #e2e2e2;
     border-top: 5px solid #333333;
     position: fixed;
     bottom: 0;
+    left: 0;
+    right: 0;
     text-align: center;
-    padding: 8px 0;
+    padding: 8px 5px;
     z-index: 9999;
 }


### PR DESCRIPTION
* The div will be added into the .content div. Some themes have a padding/margin for that div. Thus, I added `left: 0; right: 0;`
* Transparent background makes the message hard to read in case there is some other text underneath it.