### PR TITLE
Small tweak for taxonomy custom column filter function

### DIFF
--- a/includes/admin/class-wp-statistics-admin-taxonomy.php
+++ b/includes/admin/class-wp-statistics-admin-taxonomy.php
@@ -67,10 +67,10 @@ class Admin_Taxonomy
     /**
      * Render the custom column on the post/pages lists.
      *
-     * @param $value
+     * @param string $value
      * @param string $column_name Column Name
-     * @param $term_id
-     * @return mixed
+     * @param int $term_id
+     * @return string
      */
     public function render_column($value, $column_name, $term_id)
     {

--- a/includes/admin/class-wp-statistics-admin-taxonomy.php
+++ b/includes/admin/class-wp-statistics-admin-taxonomy.php
@@ -74,9 +74,9 @@ class Admin_Taxonomy
      */
     public function render_column($value, $column_name, $term_id)
     {
-        $term = get_term($term_id);
         if ($column_name == 'wp-statistics-tax-hits') {
-            echo "<a href='" . Menus::admin_url('pages', array('type' => $term->taxonomy, 'ID' => $term_id)) . "'>" . wp_statistics_pages('total', "", $term_id, null, null, $term->taxonomy) . "</a>";
+            $term = get_term($term_id);
+            return "<a href='" . Menus::admin_url('pages', array('type' => $term->taxonomy, 'ID' => $term_id)) . "'>" . wp_statistics_pages('total', "", $term_id, null, null, $term->taxonomy) . "</a>";
         }
 
         return $value;


### PR DESCRIPTION
Hi,
I was about to report the bug regarding the function for the custom taxonomy columns not returning any value, when I saw this already got addressed in 0f242fde401d91ee692a53385b349b58c394c03c on the development branch.

Still, I have this little suggestion for improvement, as filter functions must not echo anything.

Do you have a rough estimate, when the bug fix will be available as part of an update? A user of my plugin gets fatal errors on some taxonomy admin pages because of it.

Thanks,
Andreas