### PR TITLE
Improve post hits when sorted by views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Enhancement: Show query params alongside page name inside single visitor page.
 * Enhancement: Improved GeoIP functionality by using object caching to optimize performance and reduce redundant operations.
 * Enhancement: Enabled Geolocation functionality by default for more seamless user experience.
-* Enhancement: Enhancement: Validate hit/online request params before storing them into the database.
+* Enhancement: Validate hit/online request params before storing them into the database.
+* Enhancement: Improve post hits queries when sorted by views.
 * Fix: Fixed incorrect order in custom post types lists when sorted by views.
 * Fix: Fixed incorrect views count in admin bar.
 * Fix: Fixed incorrect views in posts and taxonomy lists.

--- a/includes/admin/class-wp-statistics-admin-post.php
+++ b/includes/admin/class-wp-statistics-admin-post.php
@@ -101,7 +101,9 @@ class Admin_Post
             }
 
             if (is_numeric($hitCount)) {
-                $preview_chart_unlock_html = sprintf('<div class="wps-admin-column__unlock"><a href="%s" target="_blank"><span class="wps-admin-column__unlock__text">%s</span><img class="wps-admin-column__unlock__lock" src="%s"/><img class="wps-admin-column__unlock__img" src="%s"/></a></div>',
+                $preview_chart_unlock_html = sprintf(
+                    // translators: 1: Mini-chart product link - 2: "Unlock This Feature!" text - 3: Lock image - 4: Chart preview image.
+                    '<div class="wps-admin-column__unlock"><a href="%s" target="_blank"><span class="wps-admin-column__unlock__text">%s</span><img class="wps-admin-column__unlock__lock" src="%s"/><img class="wps-admin-column__unlock__img" src="%s"/></a></div>',
                     'https://wp-statistics.com/product/wp-statistics-mini-chart?utm_source=wp-statistics&utm_medium=link&utm_campaign=mini-chart',
                     __('Unlock This Feature!', 'wp-statistics'),
                     WP_STATISTICS_URL . 'assets/images/mini-chart-posts-lock.svg',
@@ -124,16 +126,17 @@ class Admin_Post
                     echo apply_filters("wp_statistics_before_hit_column_{$actual_post_type}", $preview_chart_unlock_html, $post_id, $post_type); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                 }
 
-                echo sprintf('<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                echo sprintf(
+                    // translators: 1 & 2: CSS class - 3: Either "Visitors" or "Views" - 4: Link to content analytics page - 5: CSS class - 6: Hits count.
+                    '<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
                     $isMiniChartActive && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
                     $isMiniChartActive ? '' : 'wps-hide',
                     Helper::checkMiniChartOption('metric', 'visitors', 'visitors') ? esc_html__('Visitors:', 'wp-statistics') : esc_html__('Views:', 'wp-statistics'),
                     esc_url(Menus::admin_url('content-analytics', ['post_id' => $post_id, 'type' => 'single', 'from' => Request::get('from', $from), 'to' => Request::get('to', $to)])),
                     $isMiniChartActive ? '' : 'wps-admin-column__unlock-count',
-                    esc_html(number_format($hitCount)) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                    esc_html(number_format($hitCount))
                 );
             }
-
         }
     }
 
@@ -231,7 +234,9 @@ class Admin_Post
         }
 
         if ($post->post_status == 'publish') {
-            echo sprintf('<div class="misc-pub-section misc-pub-hits">%s <a href="%s">%s</a></div>',
+            echo sprintf(
+                // translators: 1: Either "Visitors" or "Views" - 2: Link to content analytics page - 3: Hits count.
+                '<div class="misc-pub-section misc-pub-hits">%s <a href="%s">%s</a></div>',
                 Helper::checkMiniChartOption('metric', 'visitors', 'visitors') ? esc_html__('Visitors:', 'wp-statistics') : esc_html__('Views:', 'wp-statistics'),
                 esc_url(Menus::admin_url('content-analytics', ['post_id' => $post->ID, 'type' => 'single', 'from' => Request::get('from', date('Y-m-d', 0)), 'to' => Request::get('to', date('Y-m-d'))])),
                 esc_html(number_format($hitCount))
@@ -253,7 +258,6 @@ class Admin_Post
             add_meta_box(Meta_Box::getMetaBoxKey(self::$hits_chart_post_meta_box), $metaBox['name'], Meta_Box::LoadMetaBox(self::$hits_chart_post_meta_box), $screen, 'normal', 'high', array('__block_editor_compatible_meta_box' => true, '__back_compat_meta_box' => false));
         }
     }
-
 }
 
 new Admin_Post;

--- a/includes/admin/class-wp-statistics-admin-post.php
+++ b/includes/admin/class-wp-statistics-admin-post.php
@@ -179,11 +179,15 @@ class Admin_Post
 
                 $clauses['fields'] .= ', (SELECT COUNT(DISTINCT `visitor_id`) FROM ' . DB::table('visitor_relationships') . ' AS `visitor_relationships` LEFT JOIN ' . DB::table('pages') . ' AS `pages` ON `visitor_relationships`.`page_id` = `pages`.`page_id` WHERE (`pages`.`type` IN ("page", "post", "product") OR `pages`.`type` LIKE "post_type_%") AND ' . $wpdb->posts . '.`ID` = `pages`.`id` ' . $dateCondition . ') AS `post_hits_sortable` ';
             } else {
+                $historicalSubQuery = '';
                 if (!empty($dateCondition)) {
                     $dateCondition = "AND `pages`.`date` $dateCondition";
+                } else {
+                    // Consider historical for total views
+                    $historicalSubQuery = ' + IFNULL((SELECT SUM(`historical`.`value`) FROM ' . DB::table('historical') . ' AS `historical` WHERE `historical`.`page_id` = ' . $wpdb->posts . '.`ID` AND `historical`.`uri` LIKE CONCAT("%", ' . $wpdb->posts . '.`post_name`, "/")), 0)';
                 }
 
-                $clauses['fields'] .= ', (SELECT SUM(`pages`.`count`) FROM ' . DB::table('pages') . ' AS `pages` WHERE (`pages`.`type` IN ("page", "post", "product") OR `pages`.`type` LIKE "post_type_%") AND ' . $wpdb->posts . '.`ID` = `pages`.`id` ' . $dateCondition . ') AS `post_hits_sortable` ';
+                $clauses['fields'] .= ', ((SELECT SUM(`pages`.`count`) FROM ' . DB::table('pages') . ' AS `pages` WHERE (`pages`.`type` IN ("page", "post", "product") OR `pages`.`type` LIKE "post_type_%") AND ' . $wpdb->posts . '.`ID` = `pages`.`id` ' . $dateCondition . ')' . $historicalSubQuery . ') AS `post_hits_sortable` ';
             }
 
             // And order by it.

--- a/includes/admin/class-wp-statistics-admin-post.php
+++ b/includes/admin/class-wp-statistics-admin-post.php
@@ -92,8 +92,11 @@ class Admin_Post
                 $viewsModel = new ViewsModel();
                 $hitCount   = $viewsModel->countViews($args);
 
-                $historicalModel = new HistoricalModel();
-                $hitCount       += $historicalModel->countUris(['page_id' => $post_id, 'uri' => wp_make_link_relative(get_permalink($post_id))]);
+                // Consider historical if `count_display` is equal to 'total'
+                if (!Helper::isAddOnActive('mini-chart') || Helper::checkMiniChartOption('count_display', 'total', 'total')) {
+                    $historicalModel = new HistoricalModel();
+                    $hitCount       += $historicalModel->countUris(['page_id' => $post_id, 'uri' => wp_make_link_relative(get_permalink($post_id))]);
+                }
             }
 
             if (is_numeric($hitCount)) {

--- a/includes/admin/class-wp-statistics-admin-taxonomy.php
+++ b/includes/admin/class-wp-statistics-admin-taxonomy.php
@@ -78,52 +78,54 @@ class Admin_Taxonomy
      */
     public function render_column($value, $column_name, $term_id)
     {
-        if ($column_name == 'wp-statistics-tax-hits') {
-            $term              = get_term($term_id);
-            $termType          = ($term->taxonomy === 'category' || $term->taxonomy === 'post_tag') ? $term->taxonomy : 'tax';
-            $termLink          = get_term_link(intval($term->term_id), $term->taxonomy);
-            $termLink          = !is_wp_error($termLink) ? wp_make_link_relative($termLink) : '';
-            $args              = ['post_id' => $term_id, 'resource_type' => $termType];
-            $isMiniChartActive = Helper::isAddOnActive('mini-chart');
+        if ($column_name !== 'wp-statistics-tax-hits') {
+            return $value;
+        }
 
-            $viewsModel = new ViewsModel();
-            $hitCount   = $viewsModel->countViewsFromPagesOnly($args);
+        $term              = get_term($term_id);
+        $termType          = ($term->taxonomy === 'category' || $term->taxonomy === 'post_tag') ? $term->taxonomy : 'tax';
+        $termLink          = get_term_link(intval($term->term_id), $term->taxonomy);
+        $termLink          = !is_wp_error($termLink) ? wp_make_link_relative($termLink) : '';
+        $args              = ['post_id' => $term_id, 'resource_type' => $termType];
+        $isMiniChartActive = Helper::isAddOnActive('mini-chart');
 
-            $historicalModel = new HistoricalModel();
-            $hitCount       += $historicalModel->countUris(['page_id' => $term_id, 'uri' => $termLink]);
+        $viewsModel = new ViewsModel();
+        $hitCount   = $viewsModel->countViewsFromPagesOnly($args);
 
-            if (is_numeric($hitCount)) {
-                $preview_chart_unlock_html = sprintf(
-                    // translators: 1: Mini-chart product link - 2: "Unlock This Feature!" text - 3: Lock image - 4: Chart preview image.
-                    '<div class="wps-admin-column__unlock"><a href="%s" target="_blank"><span class="wps-admin-column__unlock__text">%s</span><img class="wps-admin-column__unlock__lock" src="%s"/><img class="wps-admin-column__unlock__img" src="%s"/></a></div>',
-                    'https://wp-statistics.com/product/wp-statistics-mini-chart?utm_source=wp-statistics&utm_medium=link&utm_campaign=mini-chart',
-                    __('Unlock This Feature!', 'wp-statistics'),
-                    WP_STATISTICS_URL . 'assets/images/mini-chart-posts-lock.svg',
-                    WP_STATISTICS_URL . 'assets/images/mini-chart-posts-preview.svg'
-                );
+        $historicalModel = new HistoricalModel();
+        $hitCount       += $historicalModel->countUris(['page_id' => $term_id, 'uri' => $termLink]);
 
-                $setting = class_exists(WP_Statistics_Mini_Chart_Settings::class) ? get_option(WP_Statistics_Mini_Chart_Settings::get_instance()->setting_name) : '';
-                $value   = '';
-                if (
-                    !$isMiniChartActive ||
-                    (!empty($setting) && !empty($setting['active_mini_chart_' . $term->taxonomy]))
-                ) {
-                    // If add-on is not active, this line will display the "Unlock This Feature!" button
-                    // If add-on is active but current taxonomy is not selected in the settings, nothing will be displayed
-                    $value = apply_filters("wp_statistics_before_hit_column", $preview_chart_unlock_html, $term_id, $term->taxonomy);
-                }
+        if (is_numeric($hitCount)) {
+            $preview_chart_unlock_html = sprintf(
+                // translators: 1: Mini-chart product link - 2: "Unlock This Feature!" text - 3: Lock image - 4: Chart preview image.
+                '<div class="wps-admin-column__unlock"><a href="%s" target="_blank"><span class="wps-admin-column__unlock__text">%s</span><img class="wps-admin-column__unlock__lock" src="%s"/><img class="wps-admin-column__unlock__img" src="%s"/></a></div>',
+                'https://wp-statistics.com/product/wp-statistics-mini-chart?utm_source=wp-statistics&utm_medium=link&utm_campaign=mini-chart',
+                __('Unlock This Feature!', 'wp-statistics'),
+                WP_STATISTICS_URL . 'assets/images/mini-chart-posts-lock.svg',
+                WP_STATISTICS_URL . 'assets/images/mini-chart-posts-preview.svg'
+            );
 
-                $value .= sprintf(
-                    // translators: 1 & 2: CSS class - 3: "Views" text - 4: Link to category analytics page - 5: CSS class - 6: Hits count.
-                    '<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
-                    $isMiniChartActive && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
-                    $isMiniChartActive ? '' : 'wps-hide',
-                    esc_html__('Views:', 'wp-statistics'),
-                    Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term_id]),
-                    $isMiniChartActive ? '' : 'wps-admin-column__unlock-count',
-                    esc_html(number_format($hitCount))
-                );
+            $setting = class_exists(WP_Statistics_Mini_Chart_Settings::class) ? get_option(WP_Statistics_Mini_Chart_Settings::get_instance()->setting_name) : '';
+            $value   = '';
+            if (
+                !$isMiniChartActive ||
+                (!empty($setting) && !empty($setting['active_mini_chart_' . $term->taxonomy]))
+            ) {
+                // If add-on is not active, this line will display the "Unlock This Feature!" button
+                // If add-on is active but current taxonomy is not selected in the settings, nothing will be displayed
+                $value = apply_filters("wp_statistics_before_hit_column", $preview_chart_unlock_html, $term_id, $term->taxonomy);
             }
+
+            $value .= sprintf(
+                // translators: 1 & 2: CSS class - 3: "Views" text - 4: Link to category analytics page - 5: CSS class - 6: Hits count.
+                '<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
+                $isMiniChartActive && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
+                $isMiniChartActive ? '' : 'wps-hide',
+                esc_html__('Views:', 'wp-statistics'),
+                Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term_id]),
+                $isMiniChartActive ? '' : 'wps-admin-column__unlock-count',
+                esc_html(number_format($hitCount))
+            );
         }
 
         return $value;

--- a/includes/admin/class-wp-statistics-admin-taxonomy.php
+++ b/includes/admin/class-wp-statistics-admin-taxonomy.php
@@ -79,11 +79,12 @@ class Admin_Taxonomy
     public function render_column($value, $column_name, $term_id)
     {
         if ($column_name == 'wp-statistics-tax-hits') {
-            $term       = get_term($term_id);
-            $termType   = ($term->taxonomy === 'category' || $term->taxonomy === 'post_tag') ? $term->taxonomy : 'tax';
-            $termLink   = get_term_link(intval($term->term_id), $term->taxonomy);
-            $termLink   = !is_wp_error($termLink) ? wp_make_link_relative($termLink) : '';
-            $args       = ['post_id' => $term_id, 'resource_type' => $termType];
+            $term              = get_term($term_id);
+            $termType          = ($term->taxonomy === 'category' || $term->taxonomy === 'post_tag') ? $term->taxonomy : 'tax';
+            $termLink          = get_term_link(intval($term->term_id), $term->taxonomy);
+            $termLink          = !is_wp_error($termLink) ? wp_make_link_relative($termLink) : '';
+            $args              = ['post_id' => $term_id, 'resource_type' => $termType];
+            $isMiniChartActive = Helper::isAddOnActive('mini-chart');
 
             $viewsModel = new ViewsModel();
             $hitCount   = $viewsModel->countViewsFromPagesOnly($args);
@@ -102,7 +103,7 @@ class Admin_Taxonomy
                 $setting = class_exists(WP_Statistics_Mini_Chart_Settings::class) ? get_option(WP_Statistics_Mini_Chart_Settings::get_instance()->setting_name) : '';
                 $value   = '';
                 if (
-                    !Helper::isAddOnActive('mini-chart') ||
+                    !$isMiniChartActive ||
                     (!empty($setting) && !empty($setting['active_mini_chart_' . $term->taxonomy]))
                 ) {
                     // If add-on is not active, this line will display the "Unlock This Feature!" button
@@ -111,11 +112,11 @@ class Admin_Taxonomy
                 }
 
                 $value .= sprintf('<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
-                    Helper::isAddOnActive('mini-chart') && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
-                    Helper::isAddOnActive('mini-chart') ? '' : 'wps-hide',
+                    $isMiniChartActive && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
+                    $isMiniChartActive ? '' : 'wps-hide',
                     esc_html__('Views:', 'wp-statistics'),
                     Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term_id]),
-                    Helper::isAddOnActive('mini-chart') ? '' : 'wps-admin-column__unlock-count',
+                    $isMiniChartActive ? '' : 'wps-admin-column__unlock-count',
                     number_format($hitCount)
                 );
             }

--- a/includes/admin/class-wp-statistics-admin-taxonomy.php
+++ b/includes/admin/class-wp-statistics-admin-taxonomy.php
@@ -89,11 +89,16 @@ class Admin_Taxonomy
         $args              = ['post_id' => $term_id, 'resource_type' => $termType];
         $isMiniChartActive = Helper::isAddOnActive('mini-chart');
 
-        $viewsModel = new ViewsModel();
-        $hitCount   = $viewsModel->countViewsFromPagesOnly($args);
+        if (Helper::checkMiniChartOption('count_display', 'disabled', 'total')) {
+            // Don't execute queries if `count_display` is disabled
+            $hitCount = 0;
+        } else {
+            $viewsModel = new ViewsModel();
+            $hitCount   = $viewsModel->countViewsFromPagesOnly($args);
 
-        $historicalModel = new HistoricalModel();
-        $hitCount       += $historicalModel->countUris(['page_id' => $term_id, 'uri' => $termLink]);
+            $historicalModel = new HistoricalModel();
+            $hitCount       += $historicalModel->countUris(['page_id' => $term_id, 'uri' => $termLink]);
+        }
 
         if (is_numeric($hitCount)) {
             $preview_chart_unlock_html = sprintf(
@@ -119,7 +124,7 @@ class Admin_Taxonomy
             $value .= sprintf(
                 // translators: 1 & 2: CSS class - 3: "Views" text - 4: Link to category analytics page - 5: CSS class - 6: Hits count.
                 '<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
-                $isMiniChartActive && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
+                Helper::checkMiniChartOption('count_display', 'disabled', 'total') ? 'wps-hide' : '',
                 $isMiniChartActive ? '' : 'wps-hide',
                 esc_html__('Views:', 'wp-statistics'),
                 Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term_id]),

--- a/includes/admin/class-wp-statistics-admin-taxonomy.php
+++ b/includes/admin/class-wp-statistics-admin-taxonomy.php
@@ -93,7 +93,9 @@ class Admin_Taxonomy
             $hitCount       += $historicalModel->countUris(['page_id' => $term_id, 'uri' => $termLink]);
 
             if (is_numeric($hitCount)) {
-                $preview_chart_unlock_html = sprintf('<div class="wps-admin-column__unlock"><a href="%s" target="_blank"><span class="wps-admin-column__unlock__text">%s</span><img class="wps-admin-column__unlock__lock" src="%s"/><img class="wps-admin-column__unlock__img" src="%s"/></a></div>',
+                $preview_chart_unlock_html = sprintf(
+                    // translators: 1: Mini-chart product link - 2: "Unlock This Feature!" text - 3: Lock image - 4: Chart preview image.
+                    '<div class="wps-admin-column__unlock"><a href="%s" target="_blank"><span class="wps-admin-column__unlock__text">%s</span><img class="wps-admin-column__unlock__lock" src="%s"/><img class="wps-admin-column__unlock__img" src="%s"/></a></div>',
                     'https://wp-statistics.com/product/wp-statistics-mini-chart?utm_source=wp-statistics&utm_medium=link&utm_campaign=mini-chart',
                     __('Unlock This Feature!', 'wp-statistics'),
                     WP_STATISTICS_URL . 'assets/images/mini-chart-posts-lock.svg',
@@ -111,16 +113,17 @@ class Admin_Taxonomy
                     $value = apply_filters("wp_statistics_before_hit_column", $preview_chart_unlock_html, $term_id, $term->taxonomy);
                 }
 
-                $value .= sprintf('<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
+                $value .= sprintf(
+                    // translators: 1 & 2: CSS class - 3: "Views" text - 4: Link to category analytics page - 5: CSS class - 6: Hits count.
+                    '<div class="%s"><span class="%s">%s</span> <a href="%s" class="wps-admin-column__link %s">%s</a></div>',
                     $isMiniChartActive && Option::getByAddon('count_display', 'mini_chart', 'total') === 'disabled' ? 'wps-hide' : '',
                     $isMiniChartActive ? '' : 'wps-hide',
                     esc_html__('Views:', 'wp-statistics'),
                     Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term_id]),
                     $isMiniChartActive ? '' : 'wps-admin-column__unlock-count',
-                    number_format($hitCount)
+                    esc_html(number_format($hitCount))
                 );
             }
-
         }
 
         return $value;

--- a/languages/wp-statistics.pot
+++ b/languages/wp-statistics.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Statistics 14.9.3\n"
+"Project-Id-Version: WP Statistics 14.9.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-statistics\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-08-03T13:41:57+00:00\n"
+"POT-Creation-Date: 2024-08-05T08:23:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.10.0\n"
 "X-Domain: wp-statistics\n"
@@ -155,10 +155,10 @@ msgid "Action Completed"
 msgstr ""
 
 #: includes/admin/class-wp-statistics-admin-assets.php:132
-#: includes/admin/class-wp-statistics-admin-assets.php:353
-#: includes/admin/class-wp-statistics-admin-assets.php:386
+#: includes/admin/class-wp-statistics-admin-assets.php:354
+#: includes/admin/class-wp-statistics-admin-assets.php:387
 #: includes/admin/TinyMCE/class-wp-statistics-tinymce.php:54
-#: src/Models/ViewsModel.php:115
+#: src/Models/ViewsModel.php:148
 #: src/Models/VisitorsModel.php:218
 msgid "Today"
 msgstr ""
@@ -167,7 +167,7 @@ msgstr ""
 msgid "Display Other Month"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:347
+#: includes/admin/class-wp-statistics-admin-assets.php:348
 #: includes/admin/templates/pages/devices/browsers.php:40
 #: includes/admin/templates/pages/devices/browsers.php:41
 #: includes/admin/templates/pages/geographic/countries.php:46
@@ -177,11 +177,11 @@ msgstr ""
 msgid "View Details"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:348
+#: includes/admin/class-wp-statistics-admin-assets.php:349
 msgid "Reload"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:349
+#: includes/admin/class-wp-statistics-admin-assets.php:350
 #: includes/admin/templates/header.php:16
 #: includes/admin/TinyMCE/class-wp-statistics-tinymce.php:36
 #: includes/class-wp-statistics-shortcode.php:196
@@ -190,15 +190,15 @@ msgstr ""
 msgid "Online Users"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:350
+#: includes/admin/class-wp-statistics-admin-assets.php:351
 #: includes/admin/templates/layout/title.php:37
 msgid "Realtime"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:351
-#: includes/admin/class-wp-statistics-admin-assets.php:371
+#: includes/admin/class-wp-statistics-admin-assets.php:352
+#: includes/admin/class-wp-statistics-admin-assets.php:372
 #: includes/admin/class-wp-statistics-admin-network.php:62
-#: includes/admin/class-wp-statistics-admin-post.php:63
+#: includes/admin/class-wp-statistics-admin-post.php:64
 #: includes/admin/pages/class-wp-statistics-admin-page-visitors.php:34
 #: includes/admin/templates/layout/category-analytics/performance-chart.php:23
 #: includes/admin/templates/layout/category-analytics/summary.php:20
@@ -221,12 +221,12 @@ msgstr ""
 msgid "Visitors"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:352
-#: includes/admin/class-wp-statistics-admin-assets.php:381
+#: includes/admin/class-wp-statistics-admin-assets.php:353
+#: includes/admin/class-wp-statistics-admin-assets.php:382
 #: includes/admin/class-wp-statistics-admin-network.php:60
-#: includes/admin/class-wp-statistics-admin-post.php:63
-#: includes/admin/class-wp-statistics-admin-taxonomy.php:58
-#: includes/admin/class-wp-statistics-admin-taxonomy.php:65
+#: includes/admin/class-wp-statistics-admin-post.php:64
+#: includes/admin/class-wp-statistics-admin-taxonomy.php:60
+#: includes/admin/class-wp-statistics-admin-taxonomy.php:67
 #: includes/admin/class-wp-statistics-admin-user.php:33
 #: includes/admin/templates/layout/author-analytics/top-authors.php:25
 #: includes/admin/templates/layout/category-analytics/performance-chart.php:19
@@ -252,59 +252,59 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:354
-#: includes/admin/class-wp-statistics-admin-assets.php:387
+#: includes/admin/class-wp-statistics-admin-assets.php:355
+#: includes/admin/class-wp-statistics-admin-assets.php:388
 #: includes/admin/TinyMCE/class-wp-statistics-tinymce.php:55
-#: src/Models/ViewsModel.php:116
+#: src/Models/ViewsModel.php:149
 #: src/Models/VisitorsModel.php:219
 msgid "Yesterday"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:355
+#: includes/admin/class-wp-statistics-admin-assets.php:356
 msgid "Last week"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:356
-#: includes/admin/class-wp-statistics-admin-assets.php:388
-#: src/Models/ViewsModel.php:117
+#: includes/admin/class-wp-statistics-admin-assets.php:357
+#: includes/admin/class-wp-statistics-admin-assets.php:389
+#: src/Models/ViewsModel.php:150
 #: src/Models/VisitorsModel.php:220
 msgid "Last 7 days"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:357
-#: includes/admin/class-wp-statistics-admin-assets.php:390
-#: src/Models/ViewsModel.php:118
+#: includes/admin/class-wp-statistics-admin-assets.php:358
+#: includes/admin/class-wp-statistics-admin-assets.php:391
+#: src/Models/ViewsModel.php:151
 #: src/Models/VisitorsModel.php:221
 msgid "Last 30 days"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:358
-#: includes/admin/class-wp-statistics-admin-assets.php:392
-#: src/Models/ViewsModel.php:119
+#: includes/admin/class-wp-statistics-admin-assets.php:359
+#: includes/admin/class-wp-statistics-admin-assets.php:393
+#: src/Models/ViewsModel.php:152
 #: src/Models/VisitorsModel.php:222
 msgid "Last 60 days"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:359
-#: includes/admin/class-wp-statistics-admin-assets.php:393
+#: includes/admin/class-wp-statistics-admin-assets.php:360
+#: includes/admin/class-wp-statistics-admin-assets.php:394
 msgid "Last 90 days"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:360
-#: src/Models/ViewsModel.php:121
+#: includes/admin/class-wp-statistics-admin-assets.php:361
+#: src/Models/ViewsModel.php:154
 #: src/Models/VisitorsModel.php:224
 msgid "Last 12 months"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:361
+#: includes/admin/class-wp-statistics-admin-assets.php:362
 msgid "This year (Jan-Today)"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:362
+#: includes/admin/class-wp-statistics-admin-assets.php:363
 msgid "Last year"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:363
+#: includes/admin/class-wp-statistics-admin-assets.php:364
 #: includes/admin/templates/layout/author-analytics/performance-summary.php:24
 #: includes/admin/templates/layout/author-analytics/performance-summary.php:53
 #: includes/admin/templates/layout/category-analytics/overview-card.php:13
@@ -322,24 +322,24 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:364
+#: includes/admin/class-wp-statistics-admin-assets.php:365
 msgid "Daily Total"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:365
+#: includes/admin/class-wp-statistics-admin-assets.php:366
 #: includes/admin/templates/pages/refer.url.php:39
 #: includes/admin/templates/pages/top-visitors.php:16
 msgid "Date"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:366
+#: includes/admin/class-wp-statistics-admin-assets.php:367
 #: includes/admin/templates/layout/category-analytics/summary.php:17
 #: includes/admin/templates/layout/content-analytics/summary.php:17
 #: includes/admin/TinyMCE/class-wp-statistics-tinymce.php:52
 msgid "Time"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:367
+#: includes/admin/class-wp-statistics-admin-assets.php:368
 #: includes/admin/class-wp-statistics-admin-network.php:68
 #: includes/admin/templates/pages/category-analytics/category-performance.php:73
 #: includes/admin/templates/pages/category-analytics/category-single.php:76
@@ -350,15 +350,15 @@ msgstr ""
 msgid "Browsers"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:368
+#: includes/admin/class-wp-statistics-admin-assets.php:369
 msgid "#"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:369
+#: includes/admin/class-wp-statistics-admin-assets.php:370
 msgid "Country Flag"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:370
+#: includes/admin/class-wp-statistics-admin-assets.php:371
 #: includes/admin/templates/layout/category-analytics/top-countries.php:21
 #: includes/admin/templates/layout/content-analytics/top-countries.php:21
 #: includes/admin/templates/pages/country.php:10
@@ -373,40 +373,40 @@ msgstr ""
 msgid "Country"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:372
+#: includes/admin/class-wp-statistics-admin-assets.php:373
 #: includes/admin/templates/pages/online.php:51
 #: includes/admin/TinyMCE/class-wp-statistics-tinymce.php:65
 msgid "ID"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:373
+#: includes/admin/class-wp-statistics-admin-assets.php:374
 msgid "Page Title"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:374
+#: includes/admin/class-wp-statistics-admin-assets.php:375
 msgid "Page Link"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:375
+#: includes/admin/class-wp-statistics-admin-assets.php:376
 #: includes/admin/templates/layout/category-analytics/top-referring.php:22
 #: includes/admin/templates/layout/content-analytics/top-referring.php:22
 #: includes/admin/templates/pages/top.refer.php:21
 msgid "Domain Address"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:376
+#: includes/admin/class-wp-statistics-admin-assets.php:377
 msgid "Search Term"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:377
+#: includes/admin/class-wp-statistics-admin-assets.php:378
 msgid "Visitor's Browser"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:378
+#: includes/admin/class-wp-statistics-admin-assets.php:379
 msgid "Visitor's City"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:379
+#: includes/admin/class-wp-statistics-admin-assets.php:380
 #: includes/admin/templates/pages/online.php:24
 #: includes/admin/templates/pages/refer.url.php:36
 #: includes/admin/templates/pages/top-visitors.php:17
@@ -414,7 +414,7 @@ msgstr ""
 msgid "Daily Visitor Hash"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:379
+#: includes/admin/class-wp-statistics-admin-assets.php:380
 #: includes/admin/templates/pages/online.php:24
 #: includes/admin/templates/pages/refer.url.php:36
 #: includes/admin/templates/pages/top-visitors.php:17
@@ -422,88 +422,88 @@ msgstr ""
 msgid "IP Address"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:380
+#: includes/admin/class-wp-statistics-admin-assets.php:381
 msgid "Referring Site"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:382
+#: includes/admin/class-wp-statistics-admin-assets.php:383
 msgid "User Agent"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:383
+#: includes/admin/class-wp-statistics-admin-assets.php:384
 #: includes/admin/templates/optimization/resources.php:277
 #: includes/admin/templates/pages/top-visitors.php:18
 #: includes/admin/templates/pages/visitors.php:44
 msgid "Operating System"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:384
+#: includes/admin/class-wp-statistics-admin-assets.php:385
 msgid "Browser/OS Version"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:385
+#: includes/admin/class-wp-statistics-admin-assets.php:386
 msgid "Visited Page"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:389
+#: includes/admin/class-wp-statistics-admin-assets.php:390
 msgid "Last 14 days"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:391
+#: includes/admin/class-wp-statistics-admin-assets.php:392
 msgid "Last Month"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:394
-#: src/Models/ViewsModel.php:120
+#: includes/admin/class-wp-statistics-admin-assets.php:395
+#: src/Models/ViewsModel.php:153
 #: src/Models/VisitorsModel.php:223
 msgid "Last 120 days"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:395
+#: includes/admin/class-wp-statistics-admin-assets.php:396
 msgid "Last 6 months"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:396
+#: includes/admin/class-wp-statistics-admin-assets.php:397
 msgid "This year"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:397
+#: includes/admin/class-wp-statistics-admin-assets.php:398
 msgid "Go Back"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:398
+#: includes/admin/class-wp-statistics-admin-assets.php:399
 msgid "Select Custom Range..."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:399
+#: includes/admin/class-wp-statistics-admin-assets.php:400
 msgid "Additional Date Ranges"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:400
+#: includes/admin/class-wp-statistics-admin-assets.php:401
 msgid "Custom Date Range"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:401
+#: includes/admin/class-wp-statistics-admin-assets.php:402
 msgid "To (End Date)"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:402
+#: includes/admin/class-wp-statistics-admin-assets.php:403
 msgid "From (Start Date)"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:403
+#: includes/admin/class-wp-statistics-admin-assets.php:404
 msgid "Apply Range"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:404
+#: includes/admin/class-wp-statistics-admin-assets.php:405
 msgid "Sorry, there's no data available for this selection."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:405
+#: includes/admin/class-wp-statistics-admin-assets.php:406
 msgid "Total Number"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:406
+#: includes/admin/class-wp-statistics-admin-assets.php:407
 #: includes/admin/templates/pages/devices/browsers.php:18
 #: includes/admin/templates/pages/devices/categories.php:18
 #: includes/admin/templates/pages/devices/models.php:18
@@ -512,56 +512,56 @@ msgstr ""
 msgid "Percent Share"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:407
+#: includes/admin/class-wp-statistics-admin-assets.php:408
 #: src/Service/Admin/Devices/Views/SingleBrowserView.php:15
 #: src/Service/Admin/Devices/Views/SingleModelView.php:15
 #: src/Service/Admin/Devices/Views/SinglePlatformView.php:15
 msgid "Version"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:408
+#: includes/admin/class-wp-statistics-admin-assets.php:409
 msgid "Apply Filters"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:409
+#: includes/admin/class-wp-statistics-admin-assets.php:410
 msgid "All Entries"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:410
+#: includes/admin/class-wp-statistics-admin-assets.php:411
 msgid "Select Desired Time Range"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:411
+#: includes/admin/class-wp-statistics-admin-assets.php:412
 msgid "Enter a Valid IP Address"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:412
+#: includes/admin/class-wp-statistics-admin-assets.php:413
 msgid "Loading, Please Wait..."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:413
+#: includes/admin/class-wp-statistics-admin-assets.php:414
 msgid "User Information"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:414
+#: includes/admin/class-wp-statistics-admin-assets.php:415
 msgid "Failed to retrieve data. Please check the browser console and the XHR request under Network → XHR for details."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:415
+#: includes/admin/class-wp-statistics-admin-assets.php:416
 #: src/Service/Admin/PrivacyAudit/PrivacyAuditController.php:85
 msgid "Your WP Statistics settings are privacy-compliant."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:416
+#: includes/admin/class-wp-statistics-admin-assets.php:417
 #: src/Service/Admin/PrivacyAudit/PrivacyAuditController.php:100
 msgid "Your WP Statistics settings are not privacy-compliant. Please update your settings."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:417
+#: includes/admin/class-wp-statistics-admin-assets.php:418
 msgid "By manually resolving this item, please ensure your website’s privacy policy is updated to accurately reflect this setting. This is essential for maintaining compliance and transparency with your users."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:418
+#: includes/admin/class-wp-statistics-admin-assets.php:419
 #: includes/admin/templates/layout/author-analytics/top-authors.php:49
 #: includes/admin/templates/layout/author-analytics/top-authors.php:81
 #: includes/admin/templates/layout/author-analytics/top-authors.php:117
@@ -605,22 +605,22 @@ msgstr ""
 msgid "No recent data available."
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:419
+#: includes/admin/class-wp-statistics-admin-assets.php:420
 #: includes/admin/templates/pages/author-analytics/authors-report.php:31
 msgid "Published"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:420
+#: includes/admin/class-wp-statistics-admin-assets.php:421
 #: includes/admin/templates/pages/author-analytics/authors-pages.php:21
 #: includes/admin/templates/pages/author-analytics/authors-report.php:22
 msgid "Author"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:421
+#: includes/admin/class-wp-statistics-admin-assets.php:422
 msgid "View Detailed Analytics"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-assets.php:422
+#: includes/admin/class-wp-statistics-admin-assets.php:423
 msgid "Enable Now"
 msgstr ""
 
@@ -726,19 +726,19 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-post.php:98
-#: includes/admin/class-wp-statistics-admin-taxonomy.php:86
+#: includes/admin/class-wp-statistics-admin-post.php:120
+#: includes/admin/class-wp-statistics-admin-taxonomy.php:108
 msgid "Unlock This Feature!"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-post.php:122
-#: includes/admin/class-wp-statistics-admin-post.php:223
+#: includes/admin/class-wp-statistics-admin-post.php:146
+#: includes/admin/class-wp-statistics-admin-post.php:251
 msgid "Visitors:"
 msgstr ""
 
-#: includes/admin/class-wp-statistics-admin-post.php:122
-#: includes/admin/class-wp-statistics-admin-post.php:223
-#: includes/admin/class-wp-statistics-admin-taxonomy.php:105
+#: includes/admin/class-wp-statistics-admin-post.php:146
+#: includes/admin/class-wp-statistics-admin-post.php:251
+#: includes/admin/class-wp-statistics-admin-taxonomy.php:129
 msgid "Views:"
 msgstr ""
 
@@ -834,9 +834,9 @@ msgstr ""
 
 #: includes/admin/class-wp-statistics-admin-template.php:274
 #: includes/admin/templates/pages/geographic/cities.php:46
-#: includes/class-wp-statistics-geoip.php:132
-#: includes/class-wp-statistics-geoip.php:133
-#: includes/class-wp-statistics-geoip.php:134
+#: includes/class-wp-statistics-geoip.php:153
+#: includes/class-wp-statistics-geoip.php:154
+#: includes/class-wp-statistics-geoip.php:155
 #: includes/class-wp-statistics-user-agent.php:87
 #: src/Models/VisitorsModel.php:362
 msgid "Unknown"
@@ -1503,7 +1503,7 @@ msgid "This Feature is Part of the"
 msgstr ""
 
 #: includes/admin/templates/layout/partials/addon-premium-feature.php:26
-#: includes/class-wp-statistics-admin-bar.php:142
+#: includes/class-wp-statistics-admin-bar.php:159
 msgid "Upgrade Now"
 msgstr ""
 
@@ -3222,7 +3222,7 @@ msgstr ""
 
 #: includes/admin/templates/settings/add-ons/customization.php:18
 #: src/Service/Admin/CategoryAnalytics/CategoryAnalyticsManager.php:25
-#: src/Service/Admin/CategoryAnalytics/Views/SingleView.php:69
+#: src/Service/Admin/CategoryAnalytics/Views/SingleView.php:70
 #: src/Service/Admin/CategoryAnalytics/Views/TabsView.php:63
 msgid "Category Analytics"
 msgstr ""
@@ -4347,78 +4347,78 @@ msgstr ""
 msgid "Specify Post/Page ID for Detailed Page Statistics."
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:49
-#: includes/class-wp-statistics-admin-bar.php:158
+#: includes/class-wp-statistics-admin-bar.php:51
+#: includes/class-wp-statistics-admin-bar.php:175
 msgid "Explore Details"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:55
+#: includes/class-wp-statistics-admin-bar.php:57
 #: includes/class-wp-statistics-shortcode.php:199
 msgid "Page Views"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:56
+#: includes/class-wp-statistics-admin-bar.php:58
 msgid "View Page Performance"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:62
+#: includes/class-wp-statistics-admin-bar.php:64
 msgid "Category Views"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:63
+#: includes/class-wp-statistics-admin-bar.php:65
 msgid "View Category Performance"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:69
+#: includes/class-wp-statistics-admin-bar.php:71
 msgid "Tag Views"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:70
+#: includes/class-wp-statistics-admin-bar.php:72
 msgid "View Tag Performance"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:76
+#: includes/class-wp-statistics-admin-bar.php:78
 msgid "Taxonomy Views"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:77
+#: includes/class-wp-statistics-admin-bar.php:79
 msgid "View Taxonomy Performance"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:83
+#: includes/class-wp-statistics-admin-bar.php:85
 msgid "Author Views"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:84
+#: includes/class-wp-statistics-admin-bar.php:86
 msgid "View Author Performance"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:89
+#: includes/class-wp-statistics-admin-bar.php:91
 msgid "Total Website Views"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:116
+#: includes/class-wp-statistics-admin-bar.php:133
 msgid "Global Data"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:121
+#: includes/class-wp-statistics-admin-bar.php:138
 msgid "Current Page Data"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:126
+#: includes/class-wp-statistics-admin-bar.php:143
 msgid "Visitors Today"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:128
-#: includes/class-wp-statistics-admin-bar.php:134
+#: includes/class-wp-statistics-admin-bar.php:145
+#: includes/class-wp-statistics-admin-bar.php:151
 msgid "was %s last day"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:132
+#: includes/class-wp-statistics-admin-bar.php:149
 msgid "Views Today"
 msgstr ""
 
-#: includes/class-wp-statistics-admin-bar.php:141
+#: includes/class-wp-statistics-admin-bar.php:158
 msgid "Unlock full potential of Mini-chart"
 msgstr ""
 
@@ -4491,7 +4491,7 @@ msgid "Self Referral"
 msgstr ""
 
 #: includes/class-wp-statistics-exclusion.php:26
-#: includes/class-wp-statistics-pages.php:401
+#: includes/class-wp-statistics-pages.php:395
 msgid "Login Page"
 msgstr ""
 
@@ -4504,7 +4504,7 @@ msgid "Referrer Spam"
 msgstr ""
 
 #: includes/class-wp-statistics-exclusion.php:29
-#: includes/class-wp-statistics-pages.php:398
+#: includes/class-wp-statistics-pages.php:392
 msgid "Feed"
 msgstr ""
 
@@ -4552,49 +4552,41 @@ msgstr ""
 msgid "Views: %s"
 msgstr ""
 
-#: includes/class-wp-statistics-geoip.php:236
-msgid "Error: <code>gzopen()</code> Function Not Found!"
+#: includes/class-wp-statistics-geoip.php:249
+msgid "Unexpected HTTP status code %1$d while downloading GeoIP database from: %2$s"
 msgstr ""
 
-#: includes/class-wp-statistics-geoip.php:269
-msgid "Error: %1$s, Request URL: %2$s"
+#: includes/class-wp-statistics-geoip.php:253
+msgid "Error downloading GeoIP database from: %1$s - %2$s"
 msgstr ""
 
-#: includes/class-wp-statistics-geoip.php:278
-msgid "Error Creating GeoIP Database Directory. Ensure Web Server Has Directory Creation Permissions in: %s"
+#: includes/class-wp-statistics-geoip.php:262
+msgid "GeoIP Database successfully updated!"
 msgstr ""
 
-#: includes/class-wp-statistics-geoip.php:284
-msgid "Error Setting Permissions for GeoIP Database Directory. Check Write Permissions for Directories in: %s"
-msgstr ""
-
-#: includes/class-wp-statistics-geoip.php:292
-msgid "Error Downloading GeoIP Database from: %1$s - %2$s"
-msgstr ""
-
-#: includes/class-wp-statistics-geoip.php:308
-msgid "There was an error creating the GeoIP database file."
-msgstr ""
-
-#: includes/class-wp-statistics-geoip.php:321
-msgid "Error Opening Downloaded GeoIP Database for Reading: %s"
-msgstr ""
-
-#: includes/class-wp-statistics-geoip.php:326
-msgid "Error Opening Destination GeoIP Database for Writing: %s"
-msgstr ""
-
-#: includes/class-wp-statistics-geoip.php:345
-msgid "GeoIP Database Successfully Updated!"
-msgstr ""
-
-#: includes/class-wp-statistics-geoip.php:363
-#: includes/class-wp-statistics-geoip.php:366
+#: includes/class-wp-statistics-geoip.php:275
+#: includes/class-wp-statistics-geoip.php:279
 msgid "GeoIP update on"
 msgstr ""
 
-#: includes/class-wp-statistics-geoip.php:372
+#: includes/class-wp-statistics-geoip.php:287
 msgid "Error: %1$s"
+msgstr ""
+
+#: includes/class-wp-statistics-geoip.php:331
+msgid "Error creating directory: %s"
+msgstr ""
+
+#: includes/class-wp-statistics-geoip.php:337
+msgid "Failed to open GZ archive."
+msgstr ""
+
+#: includes/class-wp-statistics-geoip.php:343
+msgid "Failed to open destination file for writing."
+msgstr ""
+
+#: includes/class-wp-statistics-geoip.php:354
+msgid "Error extracting GeoIP database file."
 msgstr ""
 
 #: includes/class-wp-statistics-helper.php:832
@@ -4839,28 +4831,28 @@ msgstr ""
 msgid "Pages Views"
 msgstr ""
 
-#: includes/class-wp-statistics-pages.php:382
+#: includes/class-wp-statistics-pages.php:373
 msgid "Home Page: %s"
 msgstr ""
 
-#: includes/class-wp-statistics-pages.php:382
+#: includes/class-wp-statistics-pages.php:373
 msgid "Home Page"
 msgstr ""
 
-#: includes/class-wp-statistics-pages.php:404
+#: includes/class-wp-statistics-pages.php:398
 msgid "Search Page"
 msgstr ""
 
-#: includes/class-wp-statistics-pages.php:407
+#: includes/class-wp-statistics-pages.php:401
 msgid "404 not found (%s)"
 msgstr ""
 
-#: includes/class-wp-statistics-pages.php:415
-#: includes/class-wp-statistics-pages.php:418
+#: includes/class-wp-statistics-pages.php:409
+#: includes/class-wp-statistics-pages.php:412
 msgid "Post Archive: %s"
 msgstr ""
 
-#: includes/class-wp-statistics-pages.php:422
+#: includes/class-wp-statistics-pages.php:416
 msgid "Post Archive"
 msgstr ""
 
@@ -5240,12 +5232,12 @@ msgstr ""
 msgid "System error: %s"
 msgstr ""
 
-#: src/Models/ViewsModel.php:122
+#: src/Models/ViewsModel.php:155
 #: src/Models/VisitorsModel.php:225
 msgid "This year (Jan - Today)"
 msgstr ""
 
-#: src/Models/ViewsModel.php:123
+#: src/Models/ViewsModel.php:156
 #: src/Models/VisitorsModel.php:226
 msgid "Last Year"
 msgstr ""
@@ -5322,12 +5314,12 @@ msgstr ""
 msgid "List of terms in the selected taxonomy with metrics for content associated with each term."
 msgstr ""
 
-#: src/Service/Admin/CategoryAnalytics/Views/SingleView.php:27
+#: src/Service/Admin/CategoryAnalytics/Views/SingleView.php:28
 msgid "Invalid term id provided."
 msgstr ""
 
-#: src/Service/Admin/CategoryAnalytics/Views/SingleView.php:68
-msgid "Category: \"%s\""
+#: src/Service/Admin/CategoryAnalytics/Views/SingleView.php:69
+msgid "%s: \"%s\""
 msgstr ""
 
 #: src/Service/Admin/CategoryAnalytics/Views/TabsView.php:73
@@ -5343,7 +5335,7 @@ msgid "Category Pages"
 msgstr ""
 
 #: src/Service/Admin/CategoryAnalytics/Views/TabsView.php:80
-msgid "Shows the page views for category pages related to the selected taxonomy. Remove the tooltip for Category Analytics page"
+msgid "Shows the page views for category pages related to the selected taxonomy."
 msgstr ""
 
 #: src/Service/Admin/ContentAnalytics/Views/SingleView.php:28

--- a/readme.txt
+++ b/readme.txt
@@ -139,7 +139,8 @@ Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest versio
 * Enhancement: Show query params alongside page name inside single visitor page.
 * Enhancement: Improved GeoIP functionality by using object caching to optimize performance and reduce redundant operations.
 * Enhancement: Enabled Geolocation functionality by default for more seamless user experience.
-* Enhancement: Enhancement: Validate hit/online request params before storing them into the database.
+* Enhancement: Validate hit/online request params before storing them into the database.
+* Enhancement: Improve post hits queries when sorted by views.
 * Fix: Fixed incorrect order in custom post types lists when sorted by views.
 * Fix: Fixed incorrect views count in admin bar.
 * Fix: Fixed incorrect views in posts and taxonomy lists.


### PR DESCRIPTION
1. Consider historical results in hits order query when sorted by views. 
2. Skip historical calculation if `count_display` option is not set to `total`. 
3. Skip hits queries execution if `count_display` is disabled. 
4. Small refactors. 

 > Related to https://github.com/wp-statistics/wp-statistics/pull/512 (point 4) 
 > [Asana Card](https://app.asana.com/0/1198503983922005/1207972027852584/f)