### PR TITLE
Added deprecated notice for activate honey pot protection option

### DIFF
--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -1,6 +1,3 @@
-<?php
-use WP_Statistics\Service\Admin\NoticeHandler\Notice;
-?>
 <div class="postbox">
     <table class="form-table">
         <tbody>
@@ -87,38 +84,10 @@ use WP_Statistics\Service\Admin\NoticeHandler\Notice;
                 <p class="description"><?php echo esc_html__('Set a threshold for daily robot visits. Robots exceeding this number daily will be identified as bots.', 'wp-statistics'); ?></p>
             </td>
         </tr>
-        <?php
-            $useHoneypot = ! empty(WP_STATISTICS\Option::get('use_honeypot'));
-
-            if ($useHoneypot) {
-                Notice::renderNotice( 
-                    sprintf(
-                        wp_kses(
-                            /* translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening link tag, %4$s: Learn more text, %5$s: closing link tag */
-                            esc_html__('The WP Statistics %1$sHoney Pot Trap Page%2$s option will be removed in version 14.13. %3$s%4$s%5$s.', 'wp-statistics'),
-                           [
-                                'strong' => [],
-                                'a' => [
-                                    'href' => [],
-                                    'target' => [],
-                                ],
-                           ]
-                        ),
-                        '<strong>',
-                        '</strong>',
-                        '<a href="https://wp-statistics.com/resources/deprecating-the-honey-pot-trap-page-option/?utm_source=wp-statistics&utm_medium=link&utm_campaign=settings" target="_blank">',
-                        esc_html__( 'Learn more', 'wp-statistics' ),
-                        '</a>'
-                    ),
-                    'deprecated_honeypot',
-                    'warning'
-                );
-            }
-        ?>
         <tr valign="top">
             <th scope="row"><label for="use_honeypot"><?php esc_html_e('Activate Honey Pot Protection', 'wp-statistics'); ?></label></th>
             <td>
-                <input id="use_honeypot" type="checkbox" value="1" name="wps_use_honeypot" <?php checked($useHoneypot, true); ?>><label for="wps_use_honeypot"><?php esc_html_e('Enable', 'wp-statistics'); ?></label>
+                <input id="use_honeypot" type="checkbox" value="1" name="wps_use_honeypot" <?php echo WP_STATISTICS\Option::get('use_honeypot') == true ? "checked='checked'" : ''; ?>><label for="wps_use_honeypot"><?php esc_html_e('Enable', 'wp-statistics'); ?></label>
                 <p class="description"><?php echo esc_html__('Turn on Honey Pot to detect and filter out bots. This adds a hidden trap for malicious automated scripts.', 'wp-statistics'); ?></p>
             </td>
         </tr>

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -84,7 +84,7 @@
                 <p class="description"><?php echo esc_html__('Set a threshold for daily robot visits. Robots exceeding this number daily will be identified as bots.', 'wp-statistics'); ?></p>
             </td>
         </tr>
-        
+
         <tr valign="top">
             <th scope="row"><label for="use_honeypot"><?php esc_html_e('Activate Honey Pot Protection', 'wp-statistics'); ?></label></th>
             <td>

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -84,6 +84,7 @@
                 <p class="description"><?php echo esc_html__('Set a threshold for daily robot visits. Robots exceeding this number daily will be identified as bots.', 'wp-statistics'); ?></p>
             </td>
         </tr>
+        
         <tr valign="top">
             <th scope="row"><label for="use_honeypot"><?php esc_html_e('Activate Honey Pot Protection', 'wp-statistics'); ?></label></th>
             <td>

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -1,3 +1,6 @@
+<?php
+use WP_Statistics\Service\Admin\NoticeHandler\Notice;
+?>
 <div class="postbox">
     <table class="form-table">
         <tbody>
@@ -84,11 +87,36 @@
                 <p class="description"><?php echo esc_html__('Set a threshold for daily robot visits. Robots exceeding this number daily will be identified as bots.', 'wp-statistics'); ?></p>
             </td>
         </tr>
+        <?php
+            $useHoneypot = ! empty(WP_STATISTICS\Option::get('use_honeypot'));
 
+            if ($useHoneypot) {
+                Notice::renderNotice( 
+                    sprintf(
+                        wp_kses(
+                            /* translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: Learn more link */
+                            esc_html__('The WP Statistics %1$sHoney Pot Trap Page%2$s option will be removed in version 14.13. %3$s', 'wp-statistics'),
+                            [
+                                'strong' => [],
+                                'a' => [
+                                    'href' => [],
+                                    'target' => [],
+                                ],
+                            ]
+                        ),
+                        '<strong>',
+                        '</strong>',
+                        '<a href="https://wp-statistics.com/resources/deprecating-the-honey-pot-trap-page-option/?utm_source=wp-statistics&utm_medium=link&utm_campaign=settings" target="_blank">Learn more</a>'
+                    ),
+                    'deprecated_honeypot',
+                    'warning'
+                );
+            }
+        ?>
         <tr valign="top">
             <th scope="row"><label for="use_honeypot"><?php esc_html_e('Activate Honey Pot Protection', 'wp-statistics'); ?></label></th>
             <td>
-                <input id="use_honeypot" type="checkbox" value="1" name="wps_use_honeypot" <?php echo WP_STATISTICS\Option::get('use_honeypot') == true ? "checked='checked'" : ''; ?>><label for="wps_use_honeypot"><?php esc_html_e('Enable', 'wp-statistics'); ?></label>
+                <input id="use_honeypot" type="checkbox" value="1" name="wps_use_honeypot" <?php checked($useHoneypot, true); ?>><label for="wps_use_honeypot"><?php esc_html_e('Enable', 'wp-statistics'); ?></label>
                 <p class="description"><?php echo esc_html__('Turn on Honey Pot to detect and filter out bots. This adds a hidden trap for malicious automated scripts.', 'wp-statistics'); ?></p>
             </td>
         </tr>

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -94,21 +94,23 @@ use WP_Statistics\Service\Admin\NoticeHandler\Notice;
                 Notice::renderNotice( 
                     sprintf(
                         wp_kses(
-                            /* translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: Learn more link */
-                            esc_html__('The WP Statistics %1$sHoney Pot Trap Page%2$s option will be removed in version 14.13. %3$s', 'wp-statistics'),
-                            [
+                            /* translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening link tag, %4$s: Learn more text, %5$s: closing link tag */
+                            esc_html__('The WP Statistics %1$sHoney Pot Trap Page%2$s option will be removed in version 14.13. %3$s%4$s%5$s.', 'wp-statistics'),
+                           [
                                 'strong' => [],
                                 'a' => [
                                     'href' => [],
                                     'target' => [],
                                 ],
-                            ]
+                           ]
                         ),
                         '<strong>',
                         '</strong>',
-                        '<a href="https://wp-statistics.com/resources/deprecating-the-honey-pot-trap-page-option/?utm_source=wp-statistics&utm_medium=link&utm_campaign=settings" target="_blank">Learn more</a>'
+                        '<a href="https://wp-statistics.com/resources/deprecating-the-honey-pot-trap-page-option/?utm_source=wp-statistics&utm_medium=link&utm_campaign=settings" target="_blank">',
+                        esc_html__( 'Learn more', 'wp-statistics' ),
+                        '</a>'
                     ),
-                    'deprecated_honeypot',
+                    'id',
                     'warning'
                 );
             }

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -110,7 +110,7 @@ use WP_Statistics\Service\Admin\NoticeHandler\Notice;
                         esc_html__( 'Learn more', 'wp-statistics' ),
                         '</a>'
                     ),
-                    'id',
+                    'deprecated_honeypot',
                     'warning'
                 );
             }

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ https://www.youtube.com/watch?v=jxYLVtBdhEc
 
 = 14.11.4 - 2024-**-** =
 - **Enhancement:** Added the geolocation validation in site info for better debugging.
+- **Enhancement:** Added deprecated notice for Activate Honey Pot option.
 - **Fix:** Fix the tooltip for the previous period on the monthly and weekly charts.
 
 = 14.11.3 - 2024-11-17 =

--- a/src/Service/Admin/NoticeHandler/GeneralNotices.php
+++ b/src/Service/Admin/NoticeHandler/GeneralNotices.php
@@ -119,9 +119,7 @@ class GeneralNotices
      * @return void|bool
      */
     public function deprecated_honeypot_option() {
-        $useHoneypot = ! empty(Option::get('use_honeypot'));
-
-        if (! $useHoneypot) {
+        if (empty(Option::get('use_honeypot'))) {
             return;
         }
 

--- a/src/Service/Admin/NoticeHandler/GeneralNotices.php
+++ b/src/Service/Admin/NoticeHandler/GeneralNotices.php
@@ -25,6 +25,7 @@ class GeneralNotices
         'memory_limit_check',
         'php_version_check',
         'email_report_schedule',
+        'deprecated_honeypot_option'
     );
 
     public function init()
@@ -110,5 +111,41 @@ class GeneralNotices
                 ), 'email_report_schedule', 'warning');
             }
         }
+    }
+
+    /**
+     * Add notice for deprecated honeypot option.
+     * 
+     * @return void|bool
+     */
+    public function deprecated_honeypot_option() {
+        $useHoneypot = ! empty(Option::get('use_honeypot'));
+
+        if (! $useHoneypot) {
+            return;
+        }
+
+        Notice::addNotice( 
+            sprintf(
+                wp_kses(
+                    /* translators: %1$s: opening strong tag, %2$s: closing strong tag, %3$s: opening link tag, %4$s: Learn more text, %5$s: closing link tag */
+                    esc_html__('The WP Statistics %1$sHoney Pot Trap Page%2$s option will be removed in version 14.13. %3$s%4$s%5$s.', 'wp-statistics'),
+                   [
+                        'strong' => [],
+                        'a' => [
+                            'href' => [],
+                            'target' => [],
+                        ],
+                   ]
+                ),
+                '<strong>',
+                '</strong>',
+                '<a href="https://wp-statistics.com/resources/deprecating-the-honey-pot-trap-page-option/?utm_source=wp-statistics&utm_medium=link&utm_campaign=settings" target="_blank">',
+                esc_html__( 'Learn more', 'wp-statistics' ),
+                '</a>'
+            ),
+            'deprecated_honeypot',
+            'warning'
+        );
     }
 }

--- a/src/Service/Admin/NoticeHandler/GeneralNotices.php
+++ b/src/Service/Admin/NoticeHandler/GeneralNotices.php
@@ -19,21 +19,30 @@ class GeneralNotices
      *
      * @var array
      */
-    private $core_notices = array(
-        'check_tracking_mode',
-        'performance_and_clean_up',
-        'memory_limit_check',
-        'php_version_check',
-        'email_report_schedule',
+    private $coreNotices = [
+        'checkTrackingMode',
+        'performanceAndCleanUp',
+        'memoryLimitCheck',
+        'phpVersionCheck',
+        'emailReportSchedule',
         'notifyDeprecatedHoneypotOption'
-    );
+    ];
 
+    /**
+     * Initialize the notices.
+     *
+     * @return void
+     */
     public function init()
     {
-        $this->core_notices = apply_filters('wp_statistics_admin_notices', $this->core_notices);
+        $this->coreNotices = apply_filters('wp_statistics_admin_notices', $this->coreNotices);
 
-        if (is_admin() && !Helper::is_request('ajax') && !Option::get('hide_notices') && User::Access('manage')) {
-            foreach ($this->core_notices as $notice) {
+        if ( ! is_admin() ) {
+            return;
+        }
+
+        if (!Helper::is_request('ajax') && !Option::get('hide_notices') && User::Access('manage')) {
+            foreach ($this->coreNotices as $notice) {
                 if (method_exists($this, $notice)) {
                     call_user_func([$this, $notice]);
                 }
@@ -41,82 +50,174 @@ class GeneralNotices
         }
     }
 
-    private function check_tracking_mode()
+    /**
+     * Notifies users about the deprecation of server-side tracking.
+     *
+     * @return void
+     */
+    private function checkTrackingMode()
     {
-        if (Menus::in_plugin_page()) {
-            $trackingMode = Option::get('use_cache_plugin');
-
-            if (!$trackingMode) {
-                $settingsUrl = Menus::admin_url('settings');
-                $noticeText  = sprintf('<b>WP Statistics Notice:</b> Server Side Tracking is less accurate and will be deprecated in <b>version 15</b>. Please switch to Client Side Tracking for better accuracy. <a href="%s">Update Tracking Settings</a>.', $settingsUrl);
-                Notice::addNotice($noticeText, 'deprecate_server_side_tracking', 'warning');
-            }
+        if (!Menus::in_plugin_page()) {
+            return;
         }
+
+        $trackingMode = Option::get('use_cache_plugin');
+
+        if ($trackingMode) {
+            return;
+        }
+
+        $settingsUrl = Menus::admin_url('settings');
+        $noticeText  = sprintf(
+            wp_kses(
+                /* translators: %s: settings URL */
+                __('<b>WP Statistics Notice:</b> Server Side Tracking is less accurate and will be deprecated in <b>version 15</b>. Please switch to Client Side Tracking for better accuracy. <a href="%s">Update Tracking Settings</a>.', 'wp-statistics'),
+                [
+                    'b' => [],
+                    'a' => ['href' => []],
+                ]
+            ),
+            esc_url($settingsUrl)
+        );
+
+        Notice::addNotice($noticeText, 'deprecate_server_side_tracking', 'warning');
     }
 
-    private function performance_and_clean_up()
+    /**
+     * Notifies users when database size exceeds threshold.
+     *
+     * @return void
+     */
+    private function performanceAndCleanUp()
     {
-        if (Menus::in_plugin_page()) {
-            $totalRows = $this->getCachedResult('db_rows');
+        if (!Menus::in_plugin_page()) {
+            return;
+        }
 
-            if ($totalRows === false) {
-                $totalDbRows = DB::getTableRows();
-                $totalRows   = array_sum(array_column($totalDbRows, 'rows'));
-                $this->setCachedResult('db_rows', $totalRows, WEEK_IN_SECONDS);
-            }
+        $totalRows = $this->getCachedResult('db_rows');
 
-            if ($totalRows > apply_filters('wp_statistics_notice_db_row_threshold', 500000)) {
-                $settingsUrl      = admin_url('admin.php?page=wps_settings_page&tab=advanced-settings');
-                $optimizationUrl  = admin_url('admin.php?page=wps_optimization_page');
-                $documentationUrl = 'https://wp-statistics.com/resources/optimizing-database-size-for-improved-performance/';
+        if ($totalRows === false) {
+            $totalDbRows = DB::getTableRows();
+            $totalRows   = array_sum(array_column($totalDbRows, 'rows'));
+            $this->setCachedResult('db_rows', $totalRows, WEEK_IN_SECONDS);
+        }
 
-                $message = sprintf(
+        if ($totalRows > apply_filters('wp_statistics_notice_db_row_threshold', 500000)) {
+            $settingsUrl      = admin_url('admin.php?page=wps_settings_page&tab=advanced-settings');
+            $optimizationUrl  = admin_url('admin.php?page=wps_optimization_page');
+            $documentationUrl = 'https://wp-statistics.com/resources/optimizing-database-size-for-improved-performance/';
+
+            $message = sprintf(
+                wp_kses(
+                    /* translators: %1$s: Settings URL, %2$s: Optimization URL, %3$s: Documentation URL */
                     __('<b>WP Statistics Notice (Database Maintenance Recommended):</b> Your database has accumulated many records, which could slow down your site. To improve performance, go to <a href="%1$s">Settings → Data Management</a> to enable the option that stops recording old visitor data, and visit the <a href="%2$s">Optimization page</a> to clean up your database. This process only removes detailed old visitor logs but retains aggregated data. Your other data and overall statistics will remain unchanged. For more details, <a href="%3$s" target="_blank">click here</a>.', 'wp-statistics'),
-                    esc_url($settingsUrl),
-                    esc_url($optimizationUrl),
-                    esc_url($documentationUrl)
-                );
+                    [
+                        'b' => [],
+                        'a' => [
+                            'href' => [],
+                            'target' => [],
+                        ],
+                    ]
+                ),
+                esc_url($settingsUrl),
+                esc_url($optimizationUrl),
+                esc_url($documentationUrl)
+            );
 
-                Notice::addNotice($message, 'performance_and_clean_up', 'warning');
-            }
-        }
-    }
-
-    public function memory_limit_check()
-    {
-        if (Menus::in_plugin_page()) {
-            if (Helper::checkMemoryLimit()) {
-                Notice::addNotice(__('Your server memory limit is too low. Please contact your hosting provider to increase the memory limit.', 'wp-statistics'), 'memory_limit_check', 'warning');
-            }
-        }
-    }
-
-    public function php_version_check()
-    {
-        if (version_compare(PHP_VERSION, '7.2', '<')) {
-            Notice::addNotice(__('<b>WP Statistics Important Notice:</b> Final Version for Your Current PHP Version <b>14.11</b> of WP Statistics will be the <b>last</b> update compatible with your current PHP version. To continue receiving the latest features and security updates, please upgrade your PHP to version 7.2 or higher.'), 'php_version_check', 'warning');
-        }
-    }
-
-    public function email_report_schedule()
-    {
-        if (wp_next_scheduled('wp_statistics_report_hook') && Option::get('time_report') != '0') {
-            $timeReports       = Option::get('time_report');
-            $schedulesInterval = Schedule::getSchedules();
-
-            if (!isset($schedulesInterval[$timeReports])) {
-                Notice::addNotice(sprintf(
-                    __('Please update your email report schedule due to new changes in our latest release: <a href="%1$s">Update Settings</a>.', 'wp-statistics'),
-                    Menus::admin_url('settings', array('tab' => 'notifications-settings'))
-                ), 'email_report_schedule', 'warning');
-            }
+            Notice::addNotice($message, 'performance_and_clean_up', 'warning');
         }
     }
 
     /**
-     * Add notice for deprecated honeypot option.
+     * Notifies users when server memory is insufficient.
+     *
+     * @return void
+     */
+    public function memoryLimitCheck()
+    {
+        if (! Menus::in_plugin_page()) {
+            return;
+        }
+
+        if (! Helper::checkMemoryLimit()) {
+            return;
+        }
+
+        Notice::addNotice(
+            esc_html__('Your server memory limit is too low. Please contact your hosting provider to increase the memory limit.', 'wp-statistics'),
+            'memory_limit_check',
+            'warning'
+        );
+    }
+
+    /**
+     * Notifies users about incompatible PHP versions.
+     *
+     * @return void
+     */
+    public function phpVersionCheck()
+    {
+        if (! version_compare(PHP_VERSION, '7.2', '<')) {
+            return;
+        }
+       
+        Notice::addNotice(
+            wp_kses(
+                /* translators: %s: PHP version requirement */
+                __('<b>WP Statistics Important Notice:</b> Final Version for Your Current PHP Version <b>14.11</b> of WP Statistics will be the <b>last</b> update compatible with your current PHP version. To continue receiving the latest features and security updates, please upgrade your PHP to version 7.2 or higher.', 'wp-statistics'),
+                [
+                    'b' => [],
+                ]
+            ),
+            'php_version_check',
+            'warning'
+        );
+    }
+
+    /**
+     * Notifies users about invalid email report schedules.
+     *
+     * @return void
+     */
+    public function emailReportSchedule()
+    {
+        if (Option::get('time_report') == '0') {
+            return;
+        }
+
+        if (!wp_next_scheduled('wp_statistics_report_hook')) {
+            return;
+        }
+        
+        $timeReports       = Option::get('time_report');
+        $schedulesInterval = Schedule::getSchedules();
+
+        if (isset($schedulesInterval[$timeReports])) {
+           return;
+        }
+
+        Notice::addNotice(
+            sprintf(
+                /* translators: %1$s: URL to the update settings page */
+                wp_kses(
+                    __('Please update your email report schedule due to new changes in our latest release: <a href="%1$s">Update Settings</a>.', 'wp-statistics'),
+                    [
+                        'a' => [
+                            'href' => []
+                        ]
+                    ]
+                ),
+                esc_url(Menus::admin_url('settings', ['tab' => 'notifications-settings']))
+            ),
+            'email_report_schedule',
+            'warning'
+        );
+    }
+
+    /**
+     * Notifies users about the removal of honeypot feature.
      * 
-     * @return void|bool
+     * @return void
      */
     public function notifyDeprecatedHoneypotOption() {
         if (empty(Option::get('use_honeypot'))) {
@@ -139,7 +240,7 @@ class GeneralNotices
                 '<strong>',
                 '</strong>',
                 '<a href="https://wp-statistics.com/resources/deprecating-the-honey-pot-trap-page-option/?utm_source=wp-statistics&utm_medium=link&utm_campaign=settings" target="_blank">',
-                esc_html__( 'Learn more', 'wp-statistics' ),
+                esc_html__('Learn more', 'wp-statistics'),
                 '</a>'
             ),
             'deprecated_honeypot',

--- a/src/Service/Admin/NoticeHandler/GeneralNotices.php
+++ b/src/Service/Admin/NoticeHandler/GeneralNotices.php
@@ -25,7 +25,7 @@ class GeneralNotices
         'memory_limit_check',
         'php_version_check',
         'email_report_schedule',
-        'deprecated_honeypot_option'
+        'notifyDeprecatedHoneypotOption'
     );
 
     public function init()
@@ -118,7 +118,7 @@ class GeneralNotices
      * 
      * @return void|bool
      */
-    public function deprecated_honeypot_option() {
+    public function notifyDeprecatedHoneypotOption() {
         if (empty(Option::get('use_honeypot'))) {
             return;
         }


### PR DESCRIPTION
### Describe your changes
A deprecation notice for the Activate Honey Pot option was added to the settings.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207808652248107