### PR TITLE
fix: Fix urlToDir function for Bedrock

### DIFF
--- a/includes/class-wp-statistics-helper.php
+++ b/includes/class-wp-statistics-helper.php
@@ -1652,19 +1652,23 @@ class Helper
      *
      * @param string $url
      *
-     * @return  string          DIR. Empty on error.
+     * @return string DIR. Empty on error.
      */
     public static function urlToDir($url)
     {
-        if (stripos($url, site_url()) === false) {
+        // Ensure the URL is within the site scope
+        if (stripos($url, home_url()) === false) {
             return '';
         }
 
-        return (str_replace(
-            site_url(),
-            wp_normalize_path(untrailingslashit(ABSPATH)),
-            $url
-        ));
+        // Extract the plugin name from the URL (basename of the URL)
+        $pluginName = basename($url);
+
+        // Get the base directory from WP_PLUGIN_DIR
+        $pluginDir = untrailingslashit(WP_PLUGIN_DIR);
+
+        // Combine the plugin directory path with the plugin name
+        return wp_normalize_path($pluginDir . '/' . $pluginName);
     }
 
     public static function getReportEmailTip()

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,8 @@ https://www.youtube.com/watch?v=jxYLVtBdhEc
 
 = 14.11.4 - 2024-**-** =
 - **Enhancement:** Added the geolocation validation in site info for better debugging.
-- **Fix:** Fix the tooltip for the previous period on the monthly and weekly charts.
+- **Fix:** Fixed the tooltip for the previous period on the monthly and weekly charts.
+- **Fix:** Corrected `urlToDir` function to resolve plugin paths properly in Bedrock.
 
 = 14.11.3 - 2024-11-17 =
 - **New:** Added support for tracking unique visitors in shortcodes.


### PR DESCRIPTION
### Describe your changes
This PR fixes the `urlToDir` function to correctly resolve plugin paths in Bedrock environments. It uses `WP_PLUGIN_DIR` and `basename()` to eliminate redundant path segments, ensuring the correct directory path is returned without duplication of /app.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208890840860976