### PR TITLE
Fix early translation loading issue

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,9 @@ Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest versio
 == Changelog ==
 https://www.youtube.com/watch?v=jxYLVtBdhEc
 
+= 14.11.5 - 2024-**-** =
+- **Fix:** Resolved early translation loading issue.
+
 = 14.11.4 - 2024-12-09 =
 - **New:** Added a reset button to the referral filter for easier resetting.
 - **Enhancement:** Optimized performance for the Global Visitor Distribution widget.

--- a/src/Service/Admin/LicenseManagement/LicenseManagementManager.php
+++ b/src/Service/Admin/LicenseManagement/LicenseManagementManager.php
@@ -17,12 +17,12 @@ class LicenseManagementManager
 
     public function __construct()
     {
-        $this->pluginHandler   = new PluginHandler();
+        $this->pluginHandler = new PluginHandler();
 
-        // Initialize the necessary components
+        // Initialize the necessary components.
         $this->initActionCallbacks();
-        $this->initPluginUpdaters();
-
+        
+        add_action('init', [$this, 'initPluginUpdaters']);
         add_action('admin_init', [$this, 'showPluginActivationNotice']);
         add_filter('wp_statistics_enable_upgrade_to_bundle', [$this, 'showUpgradeToBundle']);
         add_filter('wp_statistics_admin_menu_list', [$this, 'addMenuItem']);
@@ -55,7 +55,7 @@ class LicenseManagementManager
     /**
      * Initialize the PluginUpdater for all stored licenses.
      */
-    private function initPluginUpdaters()
+    public function initPluginUpdaters()
     {
         $storedLicenses = LicenseHelper::getLicenses();
 


### PR DESCRIPTION
### Describe your changes
This update fixes the early translation loading issue by moving the `get_plugin_data` function call to the `init` hook.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208846701744807