### PR TITLE
Updated number display abbreviation functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Fix:** Fixed empty chart issue when selecting a 1-day range.
 - **Fix:** Resolved missing referring sites.
 - **Enhancement:** Online Visitors-related elements are now hidden when "Monitor Online Visitors" is disabled.
+- **Enhancement:** Improved number display so that numbers below 1,000 appear in full while numbers 1,000 and above are neatly abbreviated.
 
 = 14.12.4 - 2025-02-06 =
 - **Fix:** Fixed issues with Dashboard charts not loading due to an empty metalist and metaboxes not loading in specific cases.

--- a/includes/class-wp-statistics-helper.php
+++ b/includes/class-wp-statistics-helper.php
@@ -1520,26 +1520,38 @@ class Helper
      *
      * @param int|float $number The number to be formatted.
      * @param int $precision The number of decimal places to round the result to for numbers without units. Default is 0.
-     * @return string The formatted number with appropriate units.
+     * @return int|float|string Returns the original (or rounded) number if less than 1000, or a formatted string with a unit for numbers 1000 or greater.
      */
     public static function formatNumberWithUnit($number, $precision = 0)
     {
-        if (!is_numeric($number)) return 0;
-
-        $units = ['', 'K', 'M', 'B', 'T'];
-        for ($i = 0; $number >= 1000 && $i < 4; $i++) {
-            $number /= 1000;
+        if (! is_numeric($number)) {
+            return 0;
         }
 
-        if (empty($units[$i])) {
-            $formattedNumber = round($number, $precision);
-        } else {
-            $formattedNumber = round($number, 1) . $units[$i];
+        if ($number < 1000) {
+            return ! empty($precision) ? round($number, $precision) : $number;
         }
+        
+        $originalNumber = $number;
+        $units          = ['', 'K', 'M', 'B', 'T'];
+
+        $exponent = (int) floor(log($number, 1000));
+        $exponent = min($exponent, count($units) - 1);
+        
+        // Adjust the number according to the exponent.
+        $number /= pow(1000, $exponent);
+        $unit = $units[$exponent];
+        
+        // Decide on the precision:
+        // - Between 1,000 and 9,999: use two decimals.
+        // - 10,000 and above: use one decimal.
+        $factor = ($originalNumber < 10000) ? 100 : 10;
+
+        // Round the scaled number with the desired decimals and append the unit.
+        $formattedNumber = floor($number * $factor) / $factor . $unit;
 
         return $formattedNumber;
     }
-
 
     /**
      * Filters an array by keeping only the keys specified in the second argument.

--- a/tests/unit/Test_NumberFormatter.php
+++ b/tests/unit/Test_NumberFormatter.php
@@ -1,0 +1,86 @@
+<?php
+
+use WP_STATISTICS\Helper;
+
+class Test_NumberFormatter extends WP_UnitTestCase
+{
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Test that non‑numeric input returns 0.
+     */
+    public function test_non_numeric_input()
+    {
+        $this->assertSame(0, Helper::formatNumberWithUnit("abc"));
+        $this->assertSame(0, Helper::formatNumberWithUnit(null));
+        $this->assertSame("500", Helper::formatNumberWithUnit("500"));
+        $this->assertSame("1.24K", Helper::formatNumberWithUnit("1242"));
+    }
+
+    /**
+     * Test numbers below 1,000.
+     */
+    public function test_numbers_below_1000()
+    {
+        $this->assertSame(0, Helper::formatNumberWithUnit(0));
+        $this->assertSame(500, Helper::formatNumberWithUnit(500));
+        $this->assertSame(999, Helper::formatNumberWithUnit(999));
+        $this->assertSame(500.1, Helper::formatNumberWithUnit(500.123, 1));
+        $this->assertSame(500.12, Helper::formatNumberWithUnit(500.123, 2));
+    }
+
+    /**
+     * Test numbers between 1,000 and 9,999.
+     */
+    public function test_numbers_between_1000_and_9999()
+    {
+        $this->assertSame("1.24K", Helper::formatNumberWithUnit(1242));
+        $this->assertSame("9.99K", Helper::formatNumberWithUnit(9999));
+        $this->assertSame("1K", Helper::formatNumberWithUnit(1000));
+    }
+
+    /**
+     * Test numbers 10,000 and above.
+     */
+    public function test_numbers_10000_and_above()
+    {
+        $this->assertSame("18.7K", Helper::formatNumberWithUnit(18754));
+        $this->assertSame("1.5M", Helper::formatNumberWithUnit(1500000));
+    }
+
+    /**
+     * Test formatting of negative numbers.
+     *
+     * Adjust these expectations based on how negative numbers should be handled.
+     */
+    public function test_negative_numbers(): void
+    {
+        $this->assertSame(-500, Helper::formatNumberWithUnit(-500));
+        $this->assertSame(round(-500.123, 1), Helper::formatNumberWithUnit(-500.123, 1));
+        $this->assertSame(-1242, Helper::formatNumberWithUnit(-1242));
+    }
+
+    /**
+     * Test custom precision parameter handling.
+     *
+     * For numbers below 1000, the passed precision is applied.
+     * For numbers 1000 and above, the method uses its fixed rounding logic.
+     */
+    public function test_custom_precision_parameter(): void
+    {
+        // For a number between 1000 and 9999, the fixed rounding applies:
+        $this->assertSame('1.24K', Helper::formatNumberWithUnit(1242, 1));
+        $this->assertSame('1.24K', Helper::formatNumberWithUnit(1242, 2));
+        $this->assertSame('12.4M', Helper::formatNumberWithUnit(12423535, 2));
+        $this->assertSame('12.4M', Helper::formatNumberWithUnit(12483535, 2));
+
+        // For a number below 1000, the custom precision is applied.
+        $this->assertSame(500.123, Helper::formatNumberWithUnit(500.123, 3));
+        $this->assertSame(500.12, Helper::formatNumberWithUnit(500.124, 2));
+        $this->assertSame(500.13, Helper::formatNumberWithUnit(500.128, 2));
+    }
+}


### PR DESCRIPTION
### Describe your changes
This change updates the `formatNumberWithUnit` method so that numbers below 1,000 display in full (with rounding applied based on specified precision), while numbers 1,000 and above are neatly abbreviated using appropriate unit suffixes (K, M, B, T), with two decimal places for values between 1,000 and 9,999 and one decimal place for values 10,000 and above.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
