### PR TITLE
fix: DB errors due to %i usage in WP queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= 14.12.x - 2025-**-** =
+- **Fix:** Fixed database errors across the plugin caused by using `%i` for identifiers in WordPress queries.
+
 = 14.12.5 - 2025-02-** =
 - **Fix:** Fixed issues with Dashboard charts not loading due to an empty metalist and metaboxes not loading in specific cases.
 - **Fix:** Correct mini chart start date to use post creation date instead of default.

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -75,17 +75,16 @@ class Query
         if (empty($values)) return $this;
 
         foreach ($values as $field => $value) {
+            $column = '`' . str_replace('`', '``', $field) . '`';
+
             if (is_string($value)) {
-                $this->setClauses[]         = '%i = %s';
-                $this->valuesToPrepare[]    = $field;
-                $this->valuesToPrepare[]    = $value;
+                $this->setClauses[]      = "$column = %s";
+                $this->valuesToPrepare[] = $value;
             } else if (is_numeric($value)) {
-                $this->setClauses[]         = '%i = %d';
-                $this->valuesToPrepare[]    = $field;
-                $this->valuesToPrepare[]    = $value;
+                $this->setClauses[]      = "$column = %d";
+                $this->valuesToPrepare[] = $value;
             } else if (is_null($value)) {
-                $this->setClauses[]         = '%i = NULL';
-                $this->valuesToPrepare[]    = $field;
+                $this->setClauses[] = $column = NULL;
             }
         }
 
@@ -528,27 +527,26 @@ class Query
             }
 
             if (is_array($fields)) {
-                $placeholders = [];
-                $values       = [];
+                $orderParts = [];
 
-                // For identifiers with a dot (e.g. table.field) we need to split the identifier into two parts
                 foreach ($fields as $field) {
-                    if (strpos($field, '.') !== false) {
-                        $identifier  = explode('.', $field);
-                        $values      = array_merge($values, $identifier);
-                        $placeholder = '%i.%i';
+                    if (preg_match('/^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)?$/', $field)) {
+                        if (strpos($field, '.') !== false) {
+                            list($table, $column) = explode('.', $field);
+
+                            $orderParts[] = "`" . esc_sql($table) . "`.`" . esc_sql($column) . "` $order";
+                        } else {
+                            $orderParts[] = "`" . esc_sql($field) . "` $order";
+                        }
                     } else {
-                        $values[]    = $field;
-                        $placeholder = '%i';
+                        continue;
                     }
-
-                    $placeholders[] = "$placeholder $order";
                 }
-
-                $placeholders = implode(', ', $placeholders);
             }
 
-            $this->orderClause = $this->prepareQuery("ORDER BY {$placeholders}", $values);
+            if (!empty($orderParts)) {
+                $this->orderClause = 'ORDER BY ' . implode(', ', $orderParts);
+            }
         }
 
         return $this;


### PR DESCRIPTION
### Describe your changes
Fixed database errors across the application caused by using %i for identifiers in WordPress queries. This issue affected multiple areas, including Page Insight, Visitor Insight, and the Update User functionality.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `readme.txt`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208277346052303