### PR TITLE
fix: reduce the displayed record count in the Top Referring widget to 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **Fix:** Ensured `tracker.js` compatibility with the WordPress Interactivity API.
 - **Fix:** Resolved an issue where the `first_page` key was undefined on the visitor in the Visitor Insights page.
 - **Fix:** Hide 'Get More with Premium Analytics' widget for users with a premium license.
+- **Enhancement:** Reduced the displayed record count in the Top Referring widget to 5.
 
 = 14.12.6 - 2025-02-12
 - **New:** Added DB-IP as a location detection option.

--- a/src/Service/Admin/Metabox/MetaboxDataProvider.php
+++ b/src/Service/Admin/Metabox/MetaboxDataProvider.php
@@ -63,7 +63,7 @@ class MetaboxDataProvider
     {
         $args = array_merge($args, [
             'decorate'  => true,
-            'per_page'  => 10,
+            'per_page'  => 5,
             'page'      => 1
         ]);
 


### PR DESCRIPTION
### Describe your changes
Reduced the displayed record count in the Top Referring widget to 5.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209651206256103