### PR TITLE
fix: add `wp-statistics-` prefix to tags

### DIFF
--- a/src/Service/Admin/Notification/NotificationConditionTags.php
+++ b/src/Service/Admin/Notification/NotificationConditionTags.php
@@ -203,14 +203,14 @@ class NotificationConditionTags
         if (strpos($tag, 'has-addon-') === 0) {
             $addon = substr($tag, strlen('has-addon-'));
             if ($addon) {
-                return self::isAddon($addon);
+                return self::isAddon('wp-statistics-' . $addon);
             }
         }
 
         if (strpos($tag, 'no-addon-') === 0) {
             $addon = substr($tag, strlen('no-addon-'));
             if ($addon) {
-                return self::noAddon($addon);
+                return self::noAddon('wp-statistics-' . $addon);
             }
         }
 


### PR DESCRIPTION
### Describe your changes
Added `wp-statistics-` prefix to tags.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [x] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
