### PR TITLE
Add filter to disable tracker debugger error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Fix:** Fixed Decimal Formatting
 - **Fix**: Fixed visitors number aggregation issue.
 - **Fix:** Resolved posts view column issue.
+- **Enhancement:** Added `wp_statistics_disable_tracker_debugger_logs` filter to conditionally bypass tracker debugger error logging.
 
 = 14.13.4 - 2025-04-29 =
 - **Enhancement:** Enforced capability check in optionUpdater.

--- a/src/Service/Debugger/Provider/ErrorsDetectorProvider.php
+++ b/src/Service/Debugger/Provider/ErrorsDetectorProvider.php
@@ -36,6 +36,12 @@ class ErrorsDetectorProvider extends AbstractDebuggerProvider
      */
     public function errorListener()
     {
+        $disableLogs = apply_filters('wp_statistics_disable_tracker_debugger_logs', false);
+
+        if ($disableLogs) {
+            return;
+        }
+
         $error = error_get_last();
         if (empty($error)) {
             return;


### PR DESCRIPTION
### Describe your changes
Introduced the `wp_statistics_disable_tracker_debugger_logs` filter to allow disabling tracker debugger error logs.
Useful for reducing noise in logs and improving clarity in production environments.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210154290170603