### PR TITLE
fix: unify page column link behavior across dashboard based on post_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Enhancement**: Added dynamic licensing notices for add-on page.
 - **New**: Add display dynamic promo banner.
 - **New:** Added Single Resource report for for resources without post id in WordPress.
+- **Fix:** Fixed inconsistent "Page" column link behavior across all widgets and reports.
 
 = 14.13.5 - 2025-05-x =
 - **Fix:** Fixed issue where page views were zero when using a taxonomy filter other than 'category'.

--- a/views/components/tables/latest-referrals.php
+++ b/views/components/tables/latest-referrals.php
@@ -59,8 +59,8 @@ use WP_STATISTICS\Menus;
                             <td class="wps-pd-l">
                                 <?php $page = $visitor->getFirstPage(); ?>
                                 <?php if (!empty($page)) :
-                                    View::load("components/objects/external-link", [
-                                        'url'     => $page['link'],
+                                    View::load("components/objects/internal-link", [
+                                        'url'     => $page['report'],
                                         'title'   => $page['title'],
                                         'tooltip' => $page['query'] ? "?{$page['query']}" : ''
                                     ]);
@@ -72,8 +72,8 @@ use WP_STATISTICS\Menus;
                             <td class="wps-pd-l">
                                 <?php $page = $visitor->getLastPage(); ?>
                                 <?php if (!empty($page)) :
-                                    View::load("components/objects/external-link", [
-                                        'url'     => $page['link'],
+                                    View::load("components/objects/internal-link", [
+                                        'url'     => $page['report'],
                                         'title'   => $page['title'],
                                     ]);
                                 else : ?>

--- a/views/components/tables/online.php
+++ b/views/components/tables/online.php
@@ -58,8 +58,8 @@ use WP_STATISTICS\Menus;
                             <td class="wps-pd-l">
                                 <?php $page = $visitor->getLastPage(); ?>
                                 <?php if (!empty($page)) :
-                                    View::load("components/objects/external-link", [
-                                        'url'       => $page['link'],
+                                    View::load("components/objects/internal-link", [
+                                        'url'       => $page['report'],
                                         'title'     => $page['title'],
                                     ]);
                                  else : ?>

--- a/views/components/tables/referred-visitors.php
+++ b/views/components/tables/referred-visitors.php
@@ -63,8 +63,8 @@ use WP_STATISTICS\Menus;
                                 <?php $page = $visitor->getFirstPage(); ?>
 
                                 <?php if (!empty($page)) :
-                                    View::load("components/objects/external-link", [
-                                        'url'       => $page['link'],
+                                    View::load("components/objects/internal-link", [
+                                        'url'       => $page['report'],
                                         'title'     => $page['title'],
                                         'tooltip'   => $page['query'] ? "?{$page['query']}" : ''
                                     ]);
@@ -75,8 +75,8 @@ use WP_STATISTICS\Menus;
                             <td class="wps-pd-l">
                                 <?php $page = $visitor->getLastPage(); ?>
                                 <?php if (!empty($page)) :
-                                    View::load("components/objects/external-link", [
-                                        'url'   => $page['link'],
+                                    View::load("components/objects/internal-link", [
+                                        'url'   => $page['report'],
                                         'title' => $page['title'],
                                     ]);
                                 else : ?>

--- a/views/components/tables/top-entry-pages.php
+++ b/views/components/tables/top-entry-pages.php
@@ -30,7 +30,7 @@ use WP_Statistics\Components\View;
                     ?>
                         <tr>
                             <td class="wps-pd-l">
-                                <?php View::load("components/objects/external-link", [
+                                <?php View::load("components/objects/internal-link", [
                                     'url'   => Menus::admin_url('content-analytics', ['type' => 'single', 'post_id' => $page->post_id]),
                                     'title' => $pageInfo['title']
                                 ]); ?>

--- a/views/components/tables/top-visitors.php
+++ b/views/components/tables/top-visitors.php
@@ -61,8 +61,8 @@ use WP_STATISTICS\Menus;
                             $page = $visitor->getFirstPage();
 
                             if (!empty($page)) :
-                                View::load("components/objects/external-link", [
-                                    'url'       => $page['link'],
+                                View::load("components/objects/internal-link", [
+                                    'url'       => $page['report'],
                                     'title'     => $page['title'],
                                     'tooltip'   => $page['query'] ? "?{$page['query']}" : ''
                                 ]);
@@ -74,8 +74,8 @@ use WP_STATISTICS\Menus;
                         <td class="wps-pd-l">
                             <?php $page = $visitor->getLastPage(); ?>
                             <?php if (!empty($page)) :
-                                View::load("components/objects/external-link", [
-                                    'url'   => $page['link'],
+                                View::load("components/objects/internal-link", [
+                                    'url'   => $page['report'],
                                     'title' => $page['title'],
                                 ]);
                             else : ?>

--- a/views/components/tables/views.php
+++ b/views/components/tables/views.php
@@ -67,9 +67,9 @@ $viewTitle   = !empty($single_post) ? esc_html__('Page View', 'wp-statistics') :
                                     $page = $visitor->getLastPage();
 
                                     if (!empty($page)) :
-                                        View::load("components/objects/external-link", [
-                                            'url'   => $page['link'],
-                                            'title' => $page['title'],
+                                        View::load("components/objects/internal-link", [
+                                            'url'       => $page['report'],
+                                            'title'     => $page['title'],
                                         ]);
                                     else :
                                         echo Admin_Template::UnknownColumn();

--- a/views/metabox/latest-visitor.php
+++ b/views/metabox/latest-visitor.php
@@ -52,10 +52,9 @@ use WP_STATISTICS\Menus;
                     <td class="wps-pd-l">
                         <?php $page = $visitor->getLastPage(); ?>
                         <?php if (!empty($page)) :
-                            View::load("components/objects/external-link", [
-                                'url'       => $page['link'],
+                            View::load("components/objects/internal-link", [
+                                'url'       => $page['report'],
                                 'title'     => $page['title'],
-                                'tooltip'   => $page['query'] ? "?{$page['query']}" : ''
                             ]);
                         else : ?>
                             <?php echo Admin_Template::UnknownColumn() ?>

--- a/views/metabox/most-active-visitors.php
+++ b/views/metabox/most-active-visitors.php
@@ -56,29 +56,35 @@ use WP_STATISTICS\Menus;
                     </td>
 
                     <td class="wps-pd-l">
-                        <?php $page = $visitor->getFirstPage(); ?>
-                        <?php if (!empty($page)) :
-                            View::load("components/objects/external-link", [
-                                'url'       => $page['link'],
-                                'title'     => $page['title'],
-                                'tooltip'   => $page['query'] ? "?{$page['query']}" : ''
+                        <?php
+                        $firstPage = $visitor->getFirstPage();
+
+                        if (!empty($firstPage)) :
+                            View::load("components/objects/internal-link", [
+                                'url'       => $firstPage['report'],
+                                'title'     => $firstPage['title'],
+                                'tooltip'   => $firstPage['query'] ? "?{$firstPage['query']}" : ''
                             ]);
-                        else : ?>
-                            <?php echo Admin_Template::UnknownColumn() ?>
-                        <?php endif; ?>
+                        else :
+                            echo Admin_Template::UnknownColumn();
+                        endif;
+                        ?>
                     </td>
 
 
                     <td class="wps-pd-l">
-                        <?php $page = $visitor->getLastPage(); ?>
-                        <?php if (!empty($page)) :
-                            View::load("components/objects/external-link", [
-                                'url'       => $page['link'],
-                                'title'     => $page['title'],
+                        <?php
+                        $lastPage = $visitor->getLastPage();
+
+                        if (!empty($lastPage)) :
+                            View::load("components/objects/internal-link", [
+                                'url'       => $lastPage['report'],
+                                'title'     => $lastPage['title'],
                             ]);
-                        else : ?>
-                            <?php echo Admin_Template::UnknownColumn() ?>
-                        <?php endif; ?>
+                        else :
+                            echo Admin_Template::UnknownColumn();
+                        endif;
+                        ?>
                     </td>
 
                     <td class="wps-pd-l">


### PR DESCRIPTION
### Describe your changes
Fixed inconsistent "Page" column link behavior across all widgets and reports.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
