### PR TITLE
fix: hide settings and help icons based on user role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Fix:** Unseted /online endpoint from REST API when Monitor Online Visitors option is disabled.
 - **Fix:** Fixed an issue with the 'All Time' date filter displaying incorrect content details in alternative calendars.
 - **Fix:** Fixed display issue for Android app referrers in Top Referrers widget.
+- **Fix:** Hide settings and help icons based on user role.
 
 = 14.13.4 - 2025-04-29 =
 - **Enhancement:** Enforced capability check in optionUpdater.

--- a/includes/admin/templates/header.php
+++ b/includes/admin/templates/header.php
@@ -4,6 +4,7 @@ use WP_STATISTICS\Admin_Template;
 use WP_Statistics\Components\View;
 use WP_STATISTICS\Menus;
 use WP_STATISTICS\Option;
+use WP_STATISTICS\User;
 use WP_Statistics\Service\Admin\LicenseManagement\LicenseHelper;
 use WP_Statistics\Service\Admin\LicenseManagement\Plugin\PluginHelper;
 use WP_Statistics\Service\Admin\ModalHandler\Modal;
@@ -14,6 +15,8 @@ $userOnline              = new \WP_STATISTICS\UserOnline();
 $isPremium               = LicenseHelper::isPremiumLicenseAvailable() ? true : false;
 $hasUpdatedNotifications = NotificationFactory::hasUpdatedNotifications();
 $displayNotifications    = WP_STATISTICS\Option::get('display_notifications') ? true : false;
+$manageCap               = User::ExistCapability(Option::get('manage_capability', 'manage_options'));
+$hasManageCap            = $manageCap && current_user_can($manageCap);
 ?>
 
     <div class="wps-adminHeader <?php echo $isPremium ? 'wps-adminHeader__premium' : '' ?>">
@@ -83,12 +86,16 @@ $displayNotifications    = WP_STATISTICS\Option::get('display_notifications') ? 
                 <a href="<?php echo esc_url(Menus::admin_url('privacy-audit')); ?>" title="<?php esc_html_e('Privacy Audit', 'wp-statistics'); ?>" class="privacy <?php echo $privacyAuditStatus['percentage_ready'] != 100 ? 'warning' : ''; ?> <?php echo Menus::in_page('privacy-audit') ? 'active' : ''; ?>"></a>
             <?php endif; ?>
 
-            <a href="<?php echo esc_url(admin_url('admin.php?page=wps_settings_page')); ?>" title="<?php esc_html_e('Settings', 'wp-statistics'); ?>" class="settings <?php if (isset($_GET['page']) && $_GET['page'] === 'wps_settings_page') {
-                echo 'active';
-            } ?>"></a>
-            <?php if (apply_filters('wp_statistics_enable_help_icon', true)) { ?>
+            <?php if ($hasManageCap): ?>
+                <a href="<?php echo esc_url(admin_url('admin.php?page=wps_settings_page')); ?>" title="<?php esc_html_e('Settings', 'wp-statistics'); ?>" class="settings <?php if (isset($_GET['page']) && $_GET['page'] === 'wps_settings_page') {
+                    echo 'active';
+                } ?>"></a>
+            <?php endif; ?>
+
+            <?php if (apply_filters('wp_statistics_enable_help_icon', true) && $hasManageCap) { ?>
                 <a href="<?php echo esc_url(WP_STATISTICS_SITE_URL . '/support?utm_source=wp-statistics&utm_medium=link&utm_campaign=header'); ?>" target="_blank" title="<?php esc_html_e('Help Center', 'wp-statistics'); ?>" class="support"></a>
             <?php } ?>
+
             <?php if ($displayNotifications): ?>
 
                 <a title="<?php esc_html_e('Notifications', 'wp-statistics'); ?>" class="wps-notifications js-wps-open-notification <?php echo $hasUpdatedNotifications ? esc_attr('wps-notifications--has-items') : ''; ?>"></a>
@@ -113,7 +120,9 @@ $displayNotifications    = WP_STATISTICS\Option::get('display_notifications') ? 
                         echo Admin_Template::get_template('layout/partials/menu-link', ['slug' => 'wps_content-analytics_page', 'link_text' => __('Content Analytics', 'wp-statistics'), 'icon_class' => 'content-analytics', 'badge_count' => null], true);
                         echo Admin_Template::get_template('layout/partials/menu-link', ['slug' => 'wps_author-analytics_page', 'link_text' => __('Author Analytics', 'wp-statistics'), 'icon_class' => 'author-analytics', 'badge_count' => null], true);
                     }
-                    echo Admin_Template::get_template('layout/partials/menu-link', ['slug' => 'wps_settings_page', 'link_text' => __('Settings', 'wp-statistics'), 'icon_class' => 'settings', 'badge_count' => null], true);
+                    if ($hasManageCap) {
+                        echo Admin_Template::get_template('layout/partials/menu-link', ['slug' => 'wps_settings_page', 'link_text' => __('Settings', 'wp-statistics'), 'icon_class' => 'settings', 'badge_count' => null], true);
+                    }
                     ?>
                     <?php if ($displayNotifications): ?>
                         <div class="wps-admin-header__menu-item">
@@ -122,7 +131,7 @@ $displayNotifications    = WP_STATISTICS\Option::get('display_notifications') ? 
                             </a>
                         </div>
                     <?php endif; ?>
-                    <?php if (apply_filters('wp_statistics_enable_help_icon', true)) { ?>
+                    <?php if (apply_filters('wp_statistics_enable_help_icon', true) && $hasManageCap) { ?>
                         <div>
                             <a href="<?php echo esc_url(WP_STATISTICS_SITE_URL . '/support?utm_source=wp-statistics&utm_medium=link&utm_campaign=header'); ?>" target="_blank" title="<?php esc_html_e('Help Center', 'wp-statistics'); ?>" class="help">
                                 <span class="icon"></span>


### PR DESCRIPTION
### Describe your changes
Hide settings and help icons based on user role.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
