### PR TITLE
fix: resolved deprecation of the E_STRICT constant in PHP 8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - **Fix:** Resolved double slash issue in Link Report URL.
 - **Fix:** Removed the /online and /hit endpoints from the REST API when the Tracking Method is set to Server-Side Tracking (deprecated).
 - **Fix:** Made tracker.js compatible with Root Bedrock.
+- **Fix:** Resolved deprecation of the E_STRICT constant in PHP 8.4.
 
 = 14.13.4 - 2025-04-29 =
 - **Enhancement:** Enforced capability check in optionUpdater.

--- a/src/Service/Logger/AbstractLoggerProvider.php
+++ b/src/Service/Logger/AbstractLoggerProvider.php
@@ -24,30 +24,47 @@ abstract class AbstractLoggerProvider implements LoggerServiceProviderInterface
     /**
      * Map of PHP error constants to severity levels.
      */
-    protected static $ERROR_SEVERITY_MAP = [
-        // Critical errors
-        E_ERROR => 'critical',
-        E_PARSE => 'critical',
-        E_CORE_ERROR => 'critical',
-        E_COMPILE_ERROR => 'critical',
-        E_USER_ERROR => 'critical',
-        E_RECOVERABLE_ERROR => 'critical',
+    protected static $ERROR_SEVERITY_MAP = null;
 
-        // Standard errors
-        E_WARNING => 'error',
-        E_CORE_WARNING => 'error',
-        E_COMPILE_WARNING => 'error',
-        E_USER_WARNING => 'error',
+    /**
+     * Static initializer for error severity map.
+     */
+    public static function initErrorSeverityMap()
+    {
+        if (self::$ERROR_SEVERITY_MAP !== null) {
+            return self::$ERROR_SEVERITY_MAP;
+        }
 
-        // Notices
-        E_NOTICE => 'notice',
-        E_USER_NOTICE => 'notice',
-        E_STRICT => 'notice',
+        self::$ERROR_SEVERITY_MAP = [
+            // Critical errors
+            E_ERROR             => 'critical',
+            E_PARSE             => 'critical',
+            E_CORE_ERROR        => 'critical',
+            E_COMPILE_ERROR     => 'critical',
+            E_USER_ERROR        => 'critical',
+            E_RECOVERABLE_ERROR => 'critical',
 
-        // Deprecation notices
-        E_DEPRECATED => 'deprecated',
-        E_USER_DEPRECATED => 'deprecated'
-    ];
+            // Standard errors
+            E_WARNING           => 'error',
+            E_CORE_WARNING      => 'error',
+            E_COMPILE_WARNING   => 'error',
+            E_USER_WARNING      => 'error',
+
+            // Notices
+            E_NOTICE            => 'notice',
+            E_USER_NOTICE       => 'notice',
+
+            // Deprecation notices
+            E_DEPRECATED        => 'deprecated',
+            E_USER_DEPRECATED   => 'deprecated'
+        ];
+
+        if (defined('E_STRICT')) {
+            self::$ERROR_SEVERITY_MAP[E_STRICT] = 'notice';
+        }
+
+        return self::$ERROR_SEVERITY_MAP;
+    }
 
     /**
      * Sets logger identifier.
@@ -74,11 +91,11 @@ abstract class AbstractLoggerProvider implements LoggerServiceProviderInterface
         $errorName = $this->getErrorSeverity(isset($error['type']) ? $error['type'] : E_ERROR);
 
         $this->errors[] = [
-            'date' => date('Y-m-d H:i:s'),
-            'name' => $errorName,
+            'date'    => date('Y-m-d H:i:s'),
+            'name'    => $errorName,
             'message' => isset($error['message']) ? $error['message'] : '',
-            'file' => isset($error['file']) ? $error['file'] : '',
-            'line' => isset($error['line']) ? $error['line'] : 0,
+            'file'    => isset($error['file']) ? $error['file'] : '',
+            'line'    => isset($error['line']) ? $error['line'] : 0,
         ];
 
         return $this;
@@ -108,6 +125,10 @@ abstract class AbstractLoggerProvider implements LoggerServiceProviderInterface
      */
     public function getErrorSeverity($errno)
     {
+        if (self::$ERROR_SEVERITY_MAP === null) {
+            self::initErrorSeverityMap();
+        }
+
         return isset(self::$ERROR_SEVERITY_MAP[$errno]) ? self::$ERROR_SEVERITY_MAP[$errno] : 'unknown';
     }
 }


### PR DESCRIPTION
### Describe your changes
Resolved deprecation of the E_STRICT constant in PHP 8.4.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
