### PR TITLE
chore: deprecate matomo option, removal planned in future versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Enhancement:** Unset `Consent Integration` option upon integration deactivation.
 - **New:** Add Country Name to Visitor Info Flag Tooltip.
 - **New:** Added unread notification badge to Help Center menu.
+- **Enhancement:** Deprecated Matomo Referrer Spam Blacklist option; scheduled for removal in future versions.
 
 = 14.14 - 2025-06-01 =
 - **New:** Added a Help page inside the plugin to guide users.

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -201,7 +201,10 @@ use WP_STATISTICS\Menus;
 
         <tr data-id="referrer_spam_blacklist_tr">
             <th scope="row">
-                <label for="wps_settings[referrer_spam]"><?php esc_html_e('Referrer Spam Blacklist', 'wp-statistics'); ?></label>
+                <label for="wps_settings[referrer_spam]">
+                    <span><?php esc_html_e('Referrer Spam Blacklist', 'wp-statistics'); ?></span>
+                    <span class="wps-badge wps-badge--deprecated"><?php esc_html_e('DEPRECATED', 'wp-statistics'); ?></span>
+                </label>
             </th>
 
             <td>


### PR DESCRIPTION
### Describe your changes
Deprecated Matomo Referrer Spam Blacklist option; scheduled for removal in future versions.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
