### PR TITLE
fix: remove all wp statistics transients upon upgrade

### DIFF
--- a/includes/class-wp-statistics-install.php
+++ b/includes/class-wp-statistics-install.php
@@ -6,6 +6,7 @@ use WP_Statistics\Components\AssetNameObfuscator;
 use WP_Statistics\Components\Event;
 use WP_Statistics\Service\Database\Managers\TableHandler;
 use WP_Statistics\Service\Integrations\IntegrationHelper;
+use WP_Statistics\Utils\Query;
 
 class Install
 {
@@ -534,6 +535,15 @@ class Install
          */
         if (version_compare($latest_version, '14.15', '>=')) {
             Event::unschedule('wp_statistics_add_visit_hook');
+        }
+
+        /**
+         * Remove all wp statistics transients
+         */
+        if (version_compare($latest_version, '14.15.1', '>=')) {
+            Query::delete('options')
+                ->where('option_name', 'LIKE', '%wp_statistics_cache%')
+                ->execute();
         }
 
         /**


### PR DESCRIPTION
### Describe your changes
Remove all wp statistics transients upon upgrade

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [x] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
