### PR TITLE
fix: validate geographic location codes to prevent warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= 14.15.x - 2025-x-x =
+- **Fix:** Fixed a warning by validating geographic location codes are strings or integers before use.
+
 = 14.15.2 - 2025-x-x =
 - **New:** Added compatibility with the `Borlabs Cookie` plugin.
 - **New:** License keys can now be set via `wp-config.php` using constants like `WP_STATISTICS_LICENSE` and are auto-validated on init.

--- a/includes/class-wp-statistics-country.php
+++ b/includes/class-wp-statistics-country.php
@@ -51,11 +51,8 @@ class Country
     public static function getName($code)
     {
         $list_country = self::getList();
-
-        if (is_string($code) || is_int($code)) {
-            if (array_key_exists($code, $list_country)) {
-                return $list_country[$code];
-            }
+        if (array_key_exists($code, $list_country)) {
+            return $list_country[$code];
         }
 
         return $list_country[self::$unknown_location];

--- a/includes/class-wp-statistics-country.php
+++ b/includes/class-wp-statistics-country.php
@@ -51,8 +51,11 @@ class Country
     public static function getName($code)
     {
         $list_country = self::getList();
-        if (array_key_exists($code, $list_country)) {
-            return $list_country[$code];
+
+        if (is_string($code) || is_int($code)) {
+            if (array_key_exists($code, $list_country)) {
+                return $list_country[$code];
+            }
         }
 
         return $list_country[self::$unknown_location];

--- a/includes/class-wp-statistics-timezone.php
+++ b/includes/class-wp-statistics-timezone.php
@@ -307,7 +307,7 @@ class TimeZone
      */
     public static function getCountry($timezone)
     {
-        $countryCode = false;
+        $countryCode = '';
         $timezones   = timezone_identifiers_list();
 
         if (in_array($timezone, $timezones)) {


### PR DESCRIPTION
### Describe your changes
Fixed a warning by validating geographic location codes are strings or integers before use.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210986968439793