### PR TITLE
Prevent tracker_js_errors option bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= 14.15.x - 2025-xx-xx =
+- **Fix:** Prevented wp_statistics_tracker_js_errors option bloat by limiting the maximum number of saved errors and truncating error messages.
+
 = 14.15.3 - 2025-08-18 =
 - **Fix:** Fixed a warning by validating geographic location codes are strings or integers before use.
 - **Fix:** Correct redirect URL after clicking 'Start Migration'.

--- a/includes/class-wp-statistics-option.php
+++ b/includes/class-wp-statistics-option.php
@@ -366,6 +366,17 @@ class Option
         add_option($settingName, $options);
     }
 
+    public static function updateGroupOptions($group, $options)
+    {
+        $settingName = "wp_statistics_{$group}";
+
+        if (!is_array($options)) {
+            $options = [];
+        }
+
+        update_option($settingName, $options);
+    }
+
     public static function deleteOptionGroup($key, $group)
     {
         $settingName = "wp_statistics_{$group}";

--- a/src/Service/Debugger/Provider/ErrorsDetectorProvider.php
+++ b/src/Service/Debugger/Provider/ErrorsDetectorProvider.php
@@ -52,8 +52,8 @@ class ErrorsDetectorProvider extends AbstractDebuggerProvider
         $count       = count($currentLogs);
 
         if ($count >= 10) {
-            $firstKey = array_key_first($currentLogs);
-            Option::deleteOptionGroup($firstKey, self::ERROR_LOG_OPTION);
+            $currentLogs = array_slice($currentLogs, -9, null, true);
+            Option::updateGroupOptions(self::ERROR_LOG_OPTION, $currentLogs);
         }
 
         $index = 0;
@@ -62,14 +62,24 @@ class ErrorsDetectorProvider extends AbstractDebuggerProvider
             ++$index;
         }
 
+        $errorMessage     = !empty($error['message']) ? $error['message'] : '';
+        $maxMessageLength = apply_filters('wp_statistics_tracker_debugger_log_message_max_length', 1000);
+
+        if (strlen($errorMessage) > $maxMessageLength) {
+            $truncatedMessage = substr($errorMessage, 0, $maxMessageLength);
+            $truncatedMessage .= '...';
+
+            $errorMessage = $truncatedMessage;
+        }
+
         Option::saveOptionGroup(
             $index,
             [
-                'date' => date('Y-m-d H:i:s'),
-                'name' => $errorName,
-                'message' => $error['message'],
-                'file' => $error['file'],
-                'line' => $error['line'],
+                'date'    => date('Y-m-d H:i:s'),
+                'name'    => $errorName,
+                'message' => $errorMessage,
+                'file'    => $error['file'],
+                'line'    => $error['line'],
             ],
             self::ERROR_LOG_OPTION
         );


### PR DESCRIPTION
### Describe your changes
The code that limits the number of errors has been updated: instead of deleting only the first entry, it now removes the oldest entries (from the beginning of the list) as needed to cap the option group at 10 items.

Additionally, an error-message length limiter was added. Messages longer than 1000 characters are truncated to 1000. This limit is configurable via the `wp_statistics_tracker_debugger_log_message_max_length` filter.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [x] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211020990765529