### PR TITLE
fix(traffic-summary): correct final item label to 'Total' instead of …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Fix:** Prevented false `Queue Migration` notice after updates.
 - **Enhancement:** Refactored the update process and database schema updates to run on the frontend.
 - **Enhancement:** Optimized the database manager to prevent duplicate queries.
+- **Fix:** Traffic Summary widget now shows the correct final label **"Total"**, replacing the duplicated **"This year (Jan–Today)"**.
 
 = 14.15.3 - 2025-08-18 =
 - **Fix:** Fixed a warning by validating geographic location codes are strings or integers before use.

--- a/src/Models/VisitorsModel.php
+++ b/src/Models/VisitorsModel.php
@@ -543,7 +543,7 @@ class VisitorsModel extends BaseModel
             $data = $this->getVisitorsHits(array_merge($args, ['ignore_date' => true, 'historical' => true]));
 
             $summary['total'] = [
-                'label'     => $period['label'],
+                'label'     => esc_html__('Total', 'wp-statistics'),
                 'visitors'  => $data['visitors'],
                 'hits'      => $data['hits'],
             ];


### PR DESCRIPTION
### Describe your changes
Traffic Summary widget now shows the correct final label **"Total"**, replacing the duplicated **"This year (Jan–Today)"**.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211112219749931