### PR TITLE
fix: incorrect queue migration completion notice after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+= 14.15.x - 2025-xx-xx =
+- **Fix:** Corrected incorrect “Queue Migration” completion notice after plugin updates.
+
 = 14.15.4 - 2025-09-02 =
 - **Enhancement:** Refactored the update process and database schema updates to run on the frontend.
 - **Enhancement:** Optimized the database manager to avoid duplicate queries.

--- a/src/Service/Database/Managers/TableHandler.php
+++ b/src/Service/Database/Managers/TableHandler.php
@@ -64,6 +64,7 @@ class TableHandler
         Option::saveOptionGroup('is_done', null, 'ajax_background_process');
         Option::saveOptionGroup('status', null, 'ajax_background_process');
         Option::saveOptionGroup('completed', false, 'queue_background_process');
+        Option::saveOptionGroup('status', null, 'queue_background_process');
 
         $dismissedNotices = get_option('wp_statistics_dismissed_notices', []);
 


### PR DESCRIPTION
### Describe your changes
Prevents the “Queue Migration” Done notice from appearing right after an update and shows it only once the migration has actually completed.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211208992209011