### PR TITLE
feat: restrict queue and AJAX migrations to minimum role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Enhancement:** Improve compare style and number formatting in "At a Glance" widgets.
 - **Dev:** Removed `wp_statistics_data_export_base_query` and `wp_statistics_data_export_query` filters.
 - **Fix:** Resolved an issue with fresh installs during plugin activation.
+- **Enhancement:** Limited queue and AJAX migrations (and their notices) to the ` Minimum Role to Manage Settings`.
 
 = 14.15.4 - 2025-09-02 =
 - **Enhancement:** Refactored the update process and database schema updates to run on the frontend.

--- a/src/Core/Operations/Activator.php
+++ b/src/Core/Operations/Activator.php
@@ -55,10 +55,33 @@ class Activator extends AbstractCore
 
         $this->markBackgroundProcessAsInitiated();
         $this->createOptions();
-        $this->updateVersion();
+        $this->initializeVersion();
         SchemaMaintainer::repair(true);
     }
 
+    /**
+     * Ensures the plugin version is stored in the database.
+     *
+     * If the version option does not already exist, this method will
+     * initialize it by calling updateVersion().
+     *
+     * @return void
+     */
+    private function initializeVersion() {
+        $version = get_option('wp_statistics_plugin_version');
+
+        if (!empty($version)) {
+            return;
+        }
+
+        $this->updateVersion();
+    }
+
+    /**
+     * Creates the default options if they do not already exist.
+     *
+     * @return bool
+     */
     private function createOptions()
     {
         $existedOption = get_option(Option::$opt_name);

--- a/src/Service/Database/Migrations/Ajax/AjaxManager.php
+++ b/src/Service/Database/Migrations/Ajax/AjaxManager.php
@@ -7,6 +7,7 @@ use WP_STATISTICS\Menus;
 use WP_STATISTICS\Option;
 use WP_Statistics\Service\Admin\NoticeHandler\Notice;
 use WP_Statistics\Service\Database\DatabaseHelper;
+use WP_STATISTICS\User;
 use WP_Statistics\Utils\Request;
 
 /**
@@ -211,6 +212,16 @@ class AjaxManager
      */
     public function handleAjaxMigration()
     {
+        if (!User::checkUserCapability(Option::get('manage_capability', 'manage_options'))) {
+            wp_die(
+                __('You do not have sufficient permissions to run the ajax migration process.', 'wp-statistics'),
+                __('Permission Denied', 'wp-statistics'),
+                [
+                    'response' => 403
+                ]
+            );
+        }
+
         if (!Request::compare('action', self::MIGRATION_ACTION)) {
             return false;
         }
@@ -249,7 +260,7 @@ class AjaxManager
      */
     private function isValidMigrationContext()
     {
-        if (!current_user_can('manage_options')) {
+        if (!User::checkUserCapability(Option::get('manage_capability', 'manage_options'))) {
             return false;
         }
 

--- a/src/Service/Database/Migrations/Queue/QueueManager.php
+++ b/src/Service/Database/Migrations/Queue/QueueManager.php
@@ -6,6 +6,7 @@ use WP_STATISTICS\Menus;
 use WP_STATISTICS\Option;
 use WP_Statistics\Service\Admin\NoticeHandler\Notice;
 use WP_Statistics\Service\Database\DatabaseHelper;
+use WP_STATISTICS\User;
 use WP_Statistics\Utils\Request;
 
 /**
@@ -148,6 +149,16 @@ class QueueManager
      */
     public function handleQueueMigration()
     {
+        if (!User::checkUserCapability(Option::get('manage_capability', 'manage_options'))) {
+            wp_die(
+                __('You do not have sufficient permissions to run the queue migration process.', 'wp-statistics'),
+                __('Permission Denied', 'wp-statistics'),
+                [
+                    'response' => 403
+                ]
+            );
+        }
+
         if (!Request::compare('action', self::MIGRATION_ACTION) || !QueueFactory::needsMigration()) {
             return false;
         }
@@ -211,7 +222,7 @@ class QueueManager
      */
     private function isValidMigrationContext()
     {
-        if (!current_user_can('manage_options')) {
+        if (!User::checkUserCapability(Option::get('manage_capability', 'manage_options'))) {
             return false;
         }
 


### PR DESCRIPTION
### Describe your changes
Restricted the queue and AJAX migration processes (and their notices) to users with the Minimum Role to Manage Settings, ensuring that only authorized users can trigger or view migration operations. Additionally, fixed a version handling issue in the update process to maintain consistency and prevent incorrect version states.

### Submission Review Guidelines:

- I have performed a self-review of my code
- If it is a core feature, I have added thorough tests.
- Will this be part of a product update? If yes, please write one phrase about this update.
- I have reviewed my code for [security best practices](https://developer.wordpress.org/apis/security/).
- Following the above guidelines will result in quick merges and clear and detailed feedback when appropriate.
- My code follows the style guidelines of this project
- I have updated the change-log in `CHANGELOG.md`.

### Type of change

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase
-   [ ] Performance - Address performance issues
-   [ ] Enhancement - Improvement to existing functionality
