### PR TITLE
fix(tests): skip ReflectionProperty::setAccessible() on PHP 8.1+

### DIFF
--- a/tests/unit/Test_DualSaltBridge.php
+++ b/tests/unit/Test_DualSaltBridge.php
@@ -63,7 +63,12 @@ class Test_DualSaltBridge extends WP_UnitTestCase
     {
         $rc   = new ReflectionClass(Ip::class);
         $prop = $rc->getProperty('cachedIpMethod');
-        $prop->setAccessible(true);
+        // setAccessible() became no-op in PHP 8.1 and emits a deprecation
+        // warning in 8.5 — only call it on older runtimes where it's still
+        // required for non-public properties.
+        if (PHP_VERSION_ID < 80100) {
+            $prop->setAccessible(true);
+        }
         $prop->setValue(null, null);
     }
 
@@ -90,7 +95,9 @@ class Test_DualSaltBridge extends WP_UnitTestCase
         foreach ($defaults as $prop => $value) {
             if ($rc->hasProperty($prop)) {
                 $rp = $rc->getProperty($prop);
-                $rp->setAccessible(true);
+                if (PHP_VERSION_ID < 80100) {
+                    $rp->setAccessible(true);
+                }
                 $rp->setValue($payload, $value);
             }
         }


### PR DESCRIPTION
## Summary

- Test_DualSaltBridge runs each test in a separate process (`@runTestsInSeparateProcesses`) to isolate Ip's method-local static caches
- Separate-process mode applies stricter deprecation-to-exception conversion
- `ReflectionProperty::setAccessible()` is deprecated in PHP 8.5 (it became a no-op in 8.1 since non-public properties are accessible via Reflection by default)
- Result: 16 test errors on the 8.5 matrix → CI red for every PR targeting bkf-v15 (including #1092)

Gate the two calls on `PHP_VERSION_ID < 80100`. Keeps 7.4–8.0 working, silences 8.5 deprecation, no functional change.

## Test plan

- [x] Local syntax check
- [ ] CI: Run tests (7.4) — should still pass (gate evaluates true, setAccessible still called)
- [ ] CI: Run tests (8.5) — should now pass (gate skips the deprecated call)