### PR TITLE
Release v14.16.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 14.16.7 - 2026-04-**
 - **Enhancement:** Hardened output escaping and input sanitization across device reports.
+- **Enhancement:** Tracking endpoints (`wp_statistics_custom_event`, `wp_statistics_hit_record`, REST `/hit`) now return `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-cache`, so search engines no longer index these AJAX URLs and CDNs cannot cache them. Resolves spurious "ghost page" entries in Google Search Console.
 - **Fix:** Kept the **Run Migration** button on the Data Migrations screen clickable while a migration is active, so a stuck queue can be force-restarted from the UI without resorting to WP Crontrol.
 
 14.16.6 - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.7 - 2026-04-18
+- **Enhancement:** Hardened output escaping and input sanitization across device reports.
+
 14.16.6 - 2026-04-16
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.
 - **Fix:** Excluded browser prefetch and prerender requests that were inflating visit counts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-14.16.7 - 2026-04-**
-- **Enhancement:** Improved data sanitization across device reports for better security.
-- **Enhancement:** Internal tracking endpoints are no longer indexed by search engines or cached by CDNs, removing spurious "ghost page" entries from Google Search Console.
-- **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can safely delete the existing database file and it will stay deleted (issue [#1093](https://github.com/wp-statistics/wp-statistics/issues/1093)).
-- **Fix:** "Bypass Ad Blockers" no longer writes a copy of the tracker into the uploads directory, fixing compatibility with security plugins and hosting setups that lock that directory down.
-- **Fix:** The **Run Migration** button on the Data Migrations screen now stays clickable during an active migration, so stuck queues can be restarted from the UI.
-- **Deprecated:** The `wp_statistics_hashed_asset_root` and `wp_statistics_hashed_asset_dir` filters no longer affect plugin behavior because the obfuscated tracker is served from the plugin folder rather than copied into uploads/. The filters still fire for back-compat and emit a deprecation notice; they will be removed in a future release. Internal-only methods `getHashedFileUrl()`, `getHashedFilesRootDir()`, and `getHashedFileDir()` on `AssetNameObfuscator` have been removed.
+14.16.7 - 2026-05-12
+- **Enhancement:** Hardened escaping and sanitization in device reports.
+- **Enhancement:** Tracking endpoints now send noindex and no-cache headers to prevent "ghost pages" in Google Search Console.
+- **Fix:** Stopped GeoLite2-City background downloads on Cloudflare IP Geolocation sites (issue [#1093](https://github.com/wp-statistics/wp-statistics/issues/1093)).
+- **Fix:** "Bypass Ad Blockers" no longer copies the tracker into uploads, improving compatibility with hardened hosting.
+- **Fix:** **Run Migration** button stays clickable during an active migration to recover stuck queues.
+- **Deprecated:** `wp_statistics_hashed_asset_root` and `wp_statistics_hashed_asset_dir` filters; will be removed in a future release.
 
 14.16.6 - 2026-04-16
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 14.16.7 - 2026-04-**
 - **Enhancement:** Hardened output escaping and input sanitization across device reports.
 - **Enhancement:** Tracking endpoints (`wp_statistics_custom_event`, `wp_statistics_hit_record`, REST `/hit`) now return `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-cache`, so search engines no longer index these AJAX URLs and CDNs cannot cache them. Resolves spurious "ghost page" entries in Google Search Console.
+- **Fix:** Stopped the GeoLite2-City database from being silently re-downloaded on sites using the Cloudflare IP Geolocation method. The incomplete-visitor backfill job no longer forces MaxMind regardless of the configured provider, and a debug-leftover that overrode the configured provider in the **Update Country Data** admin action has been removed (issue #1093).
 - **Fix:** Kept the **Run Migration** button on the Data Migrations screen clickable while a migration is active, so a stuck queue can be force-restarted from the UI without resorting to WP Crontrol.
 
 14.16.6 - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 14.16.7 - 2026-04-**
-- **Enhancement:** Hardened output escaping and input sanitization across device reports.
-- **Enhancement:** Tracking endpoints (`wp_statistics_custom_event`, `wp_statistics_hit_record`, REST `/hit`) now return `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-cache`, so search engines no longer index these AJAX URLs and CDNs cannot cache them. Resolves spurious "ghost page" entries in Google Search Console.
-- **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can now safely delete the existing database file and it will stay deleted (issue #1093).
-- **Fix:** Kept the **Run Migration** button on the Data Migrations screen clickable while a migration is active, so a stuck queue can be force-restarted from the UI without resorting to WP Crontrol.
+- **Enhancement:** Improved data sanitization across device reports for better security.
+- **Enhancement:** Internal tracking endpoints are no longer indexed by search engines or cached by CDNs, removing spurious "ghost page" entries from Google Search Console.
+- **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can safely delete the existing database file and it will stay deleted (issue #1093).
+- **Fix:** The **Run Migration** button on the Data Migrations screen now stays clickable during an active migration, so stuck queues can be restarted from the UI.
 
 14.16.6 - 2026-04-16
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-14.16.7 - 2026-04-18
+14.16.7 - 2026-04-**
 - **Enhancement:** Hardened output escaping and input sanitization across device reports.
+- **Fix:** Kept the **Run Migration** button on the Data Migrations screen clickable while a migration is active, so a stuck queue can be force-restarted from the UI without resorting to WP Crontrol.
 
 14.16.6 - 2026-04-16
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 14.16.7 - 2026-04-**
 - **Enhancement:** Improved data sanitization across device reports for better security.
 - **Enhancement:** Internal tracking endpoints are no longer indexed by search engines or cached by CDNs, removing spurious "ghost page" entries from Google Search Console.
-- **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can safely delete the existing database file and it will stay deleted (issue #1093).
+- **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can safely delete the existing database file and it will stay deleted (issue [#1093](https://github.com/wp-statistics/wp-statistics/issues/1093)).
 - **Fix:** The **Run Migration** button on the Data Migrations screen now stays clickable during an active migration, so stuck queues can be restarted from the UI.
 
 14.16.6 - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 14.16.7 - 2026-04-**
 - **Enhancement:** Hardened output escaping and input sanitization across device reports.
 - **Enhancement:** Tracking endpoints (`wp_statistics_custom_event`, `wp_statistics_hit_record`, REST `/hit`) now return `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-cache`, so search engines no longer index these AJAX URLs and CDNs cannot cache them. Resolves spurious "ghost page" entries in Google Search Console.
-- **Fix:** Stopped the GeoLite2-City database from being silently re-downloaded on sites using the Cloudflare IP Geolocation method. The incomplete-visitor backfill job no longer forces MaxMind regardless of the configured provider, and a debug-leftover that overrode the configured provider in the **Update Country Data** admin action has been removed (issue #1093).
+- **Fix:** Stopped the GeoLite2-City database from being silently re-downloaded on sites using the Cloudflare IP Geolocation method. The auto-download path in `MaxmindGeoIPProvider::initializeReader()` now only fires when MaxMind is the configured provider, so internal callers that force MaxMind (e.g. the incomplete-visitor backfill job) no longer trigger a fresh download on cf-mode sites. The backfill job also skips itself when cf-mode is active and the database file is missing, and a debug-leftover that overrode the configured provider in the **Update Country Data** admin action has been removed (issue #1093).
 - **Fix:** Kept the **Run Migration** button on the Data Migrations screen clickable while a migration is active, so a stuck queue can be force-restarted from the UI without resorting to WP Crontrol.
 
 14.16.6 - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - **Enhancement:** Improved data sanitization across device reports for better security.
 - **Enhancement:** Internal tracking endpoints are no longer indexed by search engines or cached by CDNs, removing spurious "ghost page" entries from Google Search Console.
 - **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can safely delete the existing database file and it will stay deleted (issue [#1093](https://github.com/wp-statistics/wp-statistics/issues/1093)).
+- **Fix:** "Bypass Ad Blockers" no longer writes a copy of the tracker into the uploads directory, fixing compatibility with security plugins and hosting setups that lock that directory down.
 - **Fix:** The **Run Migration** button on the Data Migrations screen now stays clickable during an active migration, so stuck queues can be restarted from the UI.
 
 14.16.6 - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 14.16.7 - 2026-04-**
 - **Enhancement:** Hardened output escaping and input sanitization across device reports.
 - **Enhancement:** Tracking endpoints (`wp_statistics_custom_event`, `wp_statistics_hit_record`, REST `/hit`) now return `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-cache`, so search engines no longer index these AJAX URLs and CDNs cannot cache them. Resolves spurious "ghost page" entries in Google Search Console.
-- **Fix:** Stopped the GeoLite2-City database from being silently re-downloaded on sites using the Cloudflare IP Geolocation method. The auto-download path in `MaxmindGeoIPProvider::initializeReader()` now only fires when MaxMind is the configured provider, so internal callers that force MaxMind (e.g. the incomplete-visitor backfill job) no longer trigger a fresh download on cf-mode sites. The backfill job also skips itself when cf-mode is active and the database file is missing, and a debug-leftover that overrode the configured provider in the **Update Country Data** admin action has been removed (issue #1093).
+- **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can now safely delete the existing database file and it will stay deleted (issue #1093).
 - **Fix:** Kept the **Run Migration** button on the Data Migrations screen clickable while a migration is active, so a stuck queue can be force-restarted from the UI without resorting to WP Crontrol.
 
 14.16.6 - 2026-04-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Fix:** GeoLite2-City database is no longer re-downloaded in the background on sites using the Cloudflare IP Geolocation method. After switching to Cloudflare mode, you can safely delete the existing database file and it will stay deleted (issue [#1093](https://github.com/wp-statistics/wp-statistics/issues/1093)).
 - **Fix:** "Bypass Ad Blockers" no longer writes a copy of the tracker into the uploads directory, fixing compatibility with security plugins and hosting setups that lock that directory down.
 - **Fix:** The **Run Migration** button on the Data Migrations screen now stays clickable during an active migration, so stuck queues can be restarted from the UI.
+- **Deprecated:** The `wp_statistics_hashed_asset_root` and `wp_statistics_hashed_asset_dir` filters no longer affect plugin behavior because the obfuscated tracker is served from the plugin folder rather than copied into uploads/. The filters still fire for back-compat and emit a deprecation notice; they will be removed in a future release. Internal-only methods `getHashedFileUrl()`, `getHashedFilesRootDir()`, and `getHashedFileDir()` on `AssetNameObfuscator` have been removed.
 
 14.16.6 - 2026-04-16
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.

--- a/includes/admin/templates/optimization/updates.php
+++ b/includes/admin/templates/optimization/updates.php
@@ -177,8 +177,6 @@ $databaseStatus    = $schemaCheckResult['status'] ?? null;
                         $jobInstance = new $job();
                         $jobInstance->localizeJobTexts();
 
-                        $isActive = $jobInstance->is_active();
-
                         $label                = $jobInstance->getJobTitle();
                         $btnLabel             = $jobInstance->getJobButtonTitle();
                         $requiresConfirmation = $jobInstance->isConfirmationRequired() ? '1' : '0';
@@ -189,10 +187,9 @@ $databaseStatus    = $schemaCheckResult['status'] ?? null;
                             </th>
                             <td>
                                 <a
-                                    class="button wps-button wps-button--primary wps-mt-0 wps-migration-btn <?php echo !empty($isActive) ? 'disabled' : ''; ?>"
+                                    class="button wps-button wps-button--primary wps-mt-0 wps-migration-btn"
                                     title="<?php echo esc_html($label); ?>"
-                                    href="<?php echo !empty($isActive) ? '#' : esc_url($jobInstance->getActionUrl(true)); ?>"
-                                    aria-disabled="<?php echo !empty($isActive) ? 'true' : 'false'; ?>"
+                                    href="<?php echo esc_url($jobInstance->getActionUrl(true)); ?>"
                                     data-confirmation="<?php echo esc_attr($requiresConfirmation); ?>"
                                 >
                                     <?php echo !empty($btnLabel) ? esc_html($btnLabel) : esc_html__('Run Migration', 'wp-statistics'); ?>

--- a/includes/admin/templates/pages/devices/browsers.php
+++ b/includes/admin/templates/pages/devices/browsers.php
@@ -36,9 +36,9 @@ use WP_Statistics\Service\Analytics\DeviceDetection\DeviceHelper;
                                 <?php foreach ($data['visitors'] as $item) : ?>
                                     <tr>
                                         <td class="wps-pd-l">
-                                                <span title="<?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->agent); ?>" class="wps-browser-name">
-                                                    <img alt="<?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->agent); ?>" src="<?php echo esc_url(DeviceHelper::getBrowserLogo($item->agent)); ?>" class="log-tools wps-flag"/>
-                                                    <?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->agent); ?>
+                                                <span title="<?php echo esc_attr(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->agent)); ?>" class="wps-browser-name">
+                                                    <img alt="<?php echo esc_attr(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->agent)); ?>" src="<?php echo esc_url(DeviceHelper::getBrowserLogo($item->agent)); ?>" class="log-tools wps-flag"/>
+                                                    <?php echo esc_html(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->agent)); ?>
                                                 </span>
                                         </td>
                                         <td class="wps-pd-l">

--- a/includes/admin/templates/pages/devices/categories.php
+++ b/includes/admin/templates/pages/devices/categories.php
@@ -32,8 +32,8 @@ use WP_STATISTICS\Helper;
                                 <?php foreach ($data['visitors'] as $item) : ?>
                                     <tr>
                                         <td class="wps-pd-l">
-                                                <span title="<?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->device); ?>" class="wps-model-name">
-                                                    <?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->device); ?>
+                                                <span title="<?php echo esc_attr(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->device)); ?>" class="wps-model-name">
+                                                    <?php echo esc_html(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->device)); ?>
                                                 </span>
                                         </td>
                                         <td class="wps-pd-l">

--- a/includes/admin/templates/pages/devices/platforms.php
+++ b/includes/admin/templates/pages/devices/platforms.php
@@ -33,9 +33,9 @@ use WP_STATISTICS\Helper;
                                 <?php foreach ($data['visitors'] as $item) : ?>
                                     <tr>
                                         <td class="wps-pd-l">
-                                                <span title="<?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->platform); ?>" class="wps-platform-name">
-                                                    <img alt="<?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->platform); ?>" src="<?php echo esc_url(DeviceHelper::getPlatformLogo($item->platform)); ?>" class="log-tools wps-flag"/>
-                                                    <?php echo \WP_STATISTICS\Admin_Template::unknownToNotSet($item->platform); ?>
+                                                <span title="<?php echo esc_attr(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->platform)); ?>" class="wps-platform-name">
+                                                    <img alt="<?php echo esc_attr(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->platform)); ?>" src="<?php echo esc_url(DeviceHelper::getPlatformLogo($item->platform)); ?>" class="log-tools wps-flag"/>
+                                                    <?php echo esc_html(\WP_STATISTICS\Admin_Template::unknownToNotSet($item->platform)); ?>
                                                 </span>
                                         </td>
                                         <td class="wps-pd-l">

--- a/includes/api/v2/class-wp-statistics-api-hit.php
+++ b/includes/api/v2/class-wp-statistics-api-hit.php
@@ -6,6 +6,7 @@ use Exception;
 use WP_STATISTICS\Helper;
 use WP_STATISTICS\Hits;
 use WP_STATISTICS\Option;
+use WP_Statistics\Components\TrackingResponse;
 
 class Hit extends \WP_STATISTICS\RestAPI
 {
@@ -97,15 +98,7 @@ class Hit extends \WP_STATISTICS\RestAPI
             $response->set_status($statusCode);
         }
 
-        /**
-         * Tracking-endpoint headers: noindex (the URL is exposed via inline JS
-         * and Googlebot can crawl it) and Cache-Control: no-cache (so reverse
-         * proxies / CDNs do not cache and skip our PHP recording path).
-         *
-         * @link https://wordpress.org/support/topic/request-for-cloudflare-html-caching-compatibility/
-         * @since 13.0.8
-         */
-        $response->set_headers(Helper::getTrackingResponseHeaders());
+        $response->set_headers(TrackingResponse::getHeaders());
 
         return $response;
     }

--- a/includes/api/v2/class-wp-statistics-api-hit.php
+++ b/includes/api/v2/class-wp-statistics-api-hit.php
@@ -98,18 +98,14 @@ class Hit extends \WP_STATISTICS\RestAPI
         }
 
         /**
-         * Set headers for the response
+         * Tracking-endpoint headers: noindex (the URL is exposed via inline JS
+         * and Googlebot can crawl it) and Cache-Control: no-cache (so reverse
+         * proxies / CDNs do not cache and skip our PHP recording path).
          *
+         * @link https://wordpress.org/support/topic/request-for-cloudflare-html-caching-compatibility/
          * @since 13.0.8
          */
-        $response->set_headers(array(
-            /**
-             * Cache-Control for Cloudflare caching compatibility
-             *
-             * @link https://wordpress.org/support/topic/request-for-cloudflare-html-caching-compatibility/
-             */
-            'Cache-Control' => 'no-cache',
-        ));
+        $response->set_headers(Helper::getTrackingResponseHeaders());
 
         return $response;
     }

--- a/includes/class-wp-statistics-helper.php
+++ b/includes/class-wp-statistics-helper.php
@@ -16,39 +16,6 @@ use WP_Statistics\Service\Integrations\IntegrationHelper;
 class Helper
 {
     /**
-     * Headers that all tracking endpoints (custom event, hit record, REST hit)
-     * should return so the URL never appears in search engine indexes and is
-     * never cached by reverse proxies / CDNs.
-     *
-     * @return array<string,string>
-     */
-    public static function getTrackingResponseHeaders()
-    {
-        return [
-            'X-Robots-Tag'  => 'noindex, nofollow',
-            'Cache-Control' => 'no-cache',
-        ];
-    }
-
-    /**
-     * Emit the tracking response headers via header(). Use in admin-ajax
-     * handlers. REST handlers should pass the array from
-     * getTrackingResponseHeaders() to $response->set_headers() instead.
-     *
-     * @return void
-     */
-    public static function sendTrackingResponseHeaders()
-    {
-        if (headers_sent()) {
-            return;
-        }
-
-        foreach (self::getTrackingResponseHeaders() as $name => $value) {
-            header($name . ': ' . $value, true);
-        }
-    }
-
-    /**
      * Returns an array of site id's
      *
      * @return array

--- a/includes/class-wp-statistics-helper.php
+++ b/includes/class-wp-statistics-helper.php
@@ -16,6 +16,39 @@ use WP_Statistics\Service\Integrations\IntegrationHelper;
 class Helper
 {
     /**
+     * Headers that all tracking endpoints (custom event, hit record, REST hit)
+     * should return so the URL never appears in search engine indexes and is
+     * never cached by reverse proxies / CDNs.
+     *
+     * @return array<string,string>
+     */
+    public static function getTrackingResponseHeaders()
+    {
+        return [
+            'X-Robots-Tag'  => 'noindex, nofollow',
+            'Cache-Control' => 'no-cache',
+        ];
+    }
+
+    /**
+     * Emit the tracking response headers via header(). Use in admin-ajax
+     * handlers. REST handlers should pass the array from
+     * getTrackingResponseHeaders() to $response->set_headers() instead.
+     *
+     * @return void
+     */
+    public static function sendTrackingResponseHeaders()
+    {
+        if (headers_sent()) {
+            return;
+        }
+
+        foreach (self::getTrackingResponseHeaders() as $name => $value) {
+            header($name . ': ' . $value, true);
+        }
+    }
+
+    /**
      * Returns an array of site id's
      *
      * @return array

--- a/languages/wp-statistics.pot
+++ b/languages/wp-statistics.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Statistics 14.16.6\n"
+"Project-Id-Version: WP Statistics 14.16.7\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wp-statistics\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-16T05:59:43+00:00\n"
+"POT-Creation-Date: 2026-05-12T09:18:31+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: wp-statistics\n"
@@ -2405,7 +2405,7 @@ msgstr ""
 msgid "Data Migrations"
 msgstr ""
 
-#: includes/admin/templates/optimization/updates.php:198
+#: includes/admin/templates/optimization/updates.php:195
 msgid "Run Migration"
 msgstr ""
 
@@ -5453,7 +5453,7 @@ msgid "Number of views must be greater than or equal to 10!"
 msgstr ""
 
 #: includes/class-wp-statistics-rest-api.php:109
-#: src/Service/Analytics/AnalyticsController.php:51
+#: src/Service/Analytics/AnalyticsController.php:54
 msgid "Invalid signature"
 msgstr ""
 
@@ -5721,11 +5721,11 @@ msgstr ""
 msgid "render method is not defined within %s class."
 msgstr ""
 
-#: src/Components/AssetNameObfuscator.php:309
+#: src/Components/AssetNameObfuscator.php:298
 msgid "File not found."
 msgstr ""
 
-#: src/Components/AssetNameObfuscator.php:309
+#: src/Components/AssetNameObfuscator.php:298
 msgid "404 Not Found"
 msgstr ""
 
@@ -6528,56 +6528,56 @@ msgstr ""
 msgid "Event data removed for %s"
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:290
+#: src/Service/Admin/Optimization/OptimizationActions.php:288
 msgid "GeoIP update started."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:292
+#: src/Service/Admin/Optimization/OptimizationActions.php:290
 #, php-format
 msgid "GeoIP update failed: %s"
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:308
+#: src/Service/Admin/Optimization/OptimizationActions.php:306
 msgid "Source channel update started."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:310
+#: src/Service/Admin/Optimization/OptimizationActions.php:308
 #, php-format
 msgid "Source channel update failed: %s"
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:327
+#: src/Service/Admin/Optimization/OptimizationActions.php:325
 #, php-format
 msgid "Anonymized `%d` IP addresses."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:329
+#: src/Service/Admin/Optimization/OptimizationActions.php:327
 #, php-format
 msgid "IP anonymization failed: %s"
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:347
+#: src/Service/Admin/Optimization/OptimizationActions.php:345
 msgid "Database issues were found. Refresh this page to show the `Repair` button."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:350
+#: src/Service/Admin/Optimization/OptimizationActions.php:348
 msgid "Database looks good. No issues found."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:370
+#: src/Service/Admin/Optimization/OptimizationActions.php:368
 msgid "Could not repair the database. Please try again."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:373
+#: src/Service/Admin/Optimization/OptimizationActions.php:371
 msgid "Database schema issues were repaired."
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:375
+#: src/Service/Admin/Optimization/OptimizationActions.php:373
 #, php-format
 msgid "Failed to repair database schema: %s"
 msgstr ""
 
-#: src/Service/Admin/Optimization/OptimizationActions.php:425
+#: src/Service/Admin/Optimization/OptimizationActions.php:423
 msgid "Historical Data Successfully Updated."
 msgstr ""
 
@@ -7280,7 +7280,7 @@ msgstr ""
 msgid "Direct"
 msgstr ""
 
-#: src/Service/CustomEvent/CustomEventActions.php:55
+#: src/Service/CustomEvent/CustomEventActions.php:58
 msgid "Event recorded successfully."
 msgstr ""
 
@@ -7351,20 +7351,20 @@ msgstr ""
 msgid "Please <a href=\"%s\">click here</a> to process the word count in the background. This is necessary for accurate analytics."
 msgstr ""
 
-#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:48
+#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:49
 msgid "GeoIP update for incomplete visitors processed successfully."
 msgstr ""
 
-#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:49
+#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:50
 msgid "Update GeoIP for visitors without location data"
 msgstr ""
 
-#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:128
+#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:139
 #, php-format
 msgid "Detected visitors without location data. Please <a href=\"%s\">click here</a> to update the geographic data in the background. This is necessary for accurate analytics."
 msgstr ""
 
-#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:145
+#: src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php:156
 msgid "Geographic data update is already in progress."
 msgstr ""
 
@@ -7460,58 +7460,58 @@ msgid "GeoIP update on"
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:147
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:139
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:145
 #, php-format
 msgid "Unexpected HTTP status code %1$d while downloading GeoIP database from: %2$s"
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:151
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:143
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:149
 #, php-format
 msgid "Error downloading GeoIP database from: %1$s - %2$s"
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:186
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:218
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:224
 msgid "Failed to open GZ archive."
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:192
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:224
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:230
 msgid "Failed to open destination file for writing."
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:203
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:235
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:241
 msgid "Error extracting GeoIP database file."
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:227
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:269
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:275
 msgid "GeoIP database does not exist."
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:232
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:274
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:280
 #, php-format
 msgid "Failed to initialize GeoIP reader or invalid database file. Please remove the existing database file at %s and let the plugin redownload it."
 msgstr ""
 
 #: src/Service/Geolocation/Provider/DbIpProvider.php:240
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:281
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:287
 #, php-format
 msgid "Unexpected database type %s"
 msgstr ""
 
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:191
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:197
 msgid "PharData class not found."
 msgstr ""
 
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:202
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:208
 msgid "Extraction failed: File not found."
 msgstr ""
 
-#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:206
+#: src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php:212
 msgid "Failed to move extracted file."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -146,8 +146,13 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
-= 14.16.7 - 2026-04-18 =
-- **Enhancement:** Hardened output escaping and input sanitization across device reports.
+= 14.16.7 - 2026-05-12 =
+- **Enhancement:** Hardened escaping and sanitization in device reports.
+- **Enhancement:** Tracking endpoints now send noindex and no-cache headers to prevent "ghost pages" in Google Search Console.
+- **Fix:** Stopped GeoLite2-City background downloads on Cloudflare IP Geolocation sites (issue [#1093](https://github.com/wp-statistics/wp-statistics/issues/1093)).
+- **Fix:** "Bypass Ad Blockers" no longer copies the tracker into uploads, improving compatibility with hardened hosting.
+- **Fix:** **Run Migration** button stays clickable during an active migration to recover stuck queues.
+- **Deprecated:** `wp_statistics_hashed_asset_root` and `wp_statistics_hashed_asset_dir` filters; will be removed in a future release.
 
 = 14.16.6 - 2026-04-16 =
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wp-statistics.com/donate/
 Tags: analytics, google analytics, insights, stats, site visitors
 Requires at least: 6.6
 Tested up to: 7.0
-Stable tag: 14.16.6
+Stable tag: 14.16.7
 Requires PHP: 7.4
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -146,6 +146,9 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.7 - 2026-04-18 =
+- **Enhancement:** Hardened output escaping and input sanitization across device reports.
+
 = 14.16.6 - 2026-04-16 =
 - **Fix:** Removed legacy TinyMCE integration that caused "Failed to load plugin" errors in the classic editor, especially with themes like Corvix and Avada.
 - **Fix:** Excluded browser prefetch and prerender requests that were inflating visit counts.

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -244,12 +244,6 @@ class AssetNameObfuscator
             $this->uploadsDir = Helper::get_uploads_dir();
         }
 
-    private function isLegacyUploadsPath($path)
-    {
-        if (empty($this->uploadsDir)) {
-            $this->uploadsDir = Helper::get_uploads_dir();
-        }
-
         $uploadsRoot = wp_normalize_path(untrailingslashit($this->uploadsDir)) . '/';
         $normalized  = wp_normalize_path($path);
 

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -142,26 +142,26 @@ class AssetNameObfuscator
     }
 
     /**
-     * Obfuscate/Randomize file name.
+     * Register the obfuscated mapping for this asset.
+     *
+     * The proxy in HooksManager::serveObfuscatedAsset reads the original
+     * file directly via readfile(); no on-disk copy in uploads/ is needed.
+     * Legacy entries pointing into uploads/ are cleaned up here on first
+     * run after upgrade.
      *
      * @return  void
      */
     private function obfuscateFileName()
     {
-        // Return if the hashed file for this version exists
         if ($this->isHashedFileExists()) return;
 
-        // Delete old file
+        // Remove any legacy uploads/<hash>.js artifact left behind by older
+        // versions of this class.
         $this->deleteHashedFile($this->hashedAssetsArray, $this->hashedFileOptionKey);
 
-        // Copy and randomize the name of the input file
-        if (!copy($this->inputFileDir, $this->getHashedFileDir())) {
-            WP_Statistics::log("Unable to copy hashed file to {$this->getHashedFileDir()}!", 'warning');
-            return;
-        }
-
         $this->hashedAssetsArray[$this->hashedFileOptionKey]['version'] = WP_STATISTICS_VERSION;
-        $this->hashedAssetsArray[$this->hashedFileOptionKey]['dir']     = $this->getHashedFileDir();
+        $this->hashedAssetsArray[$this->hashedFileOptionKey]['dir']     = $this->inputFileDir;
+        $this->hashedAssetsArray[$this->hashedFileOptionKey]['name']    = $this->hashedFileName;
         Option::saveOptionGroup($this->hashedFileOptionKey, $this->hashedAssetsArray[$this->hashedFileOptionKey], $this->optionName);
     }
 
@@ -172,9 +172,23 @@ class AssetNameObfuscator
      */
     private function isHashedFileExists()
     {
-        return $this->hashedAssetsArray[$this->hashedFileOptionKey]['version'] === WP_STATISTICS_VERSION &&
-            !empty($this->hashedAssetsArray[$this->hashedFileOptionKey]['dir']) &&
-            file_exists($this->hashedAssetsArray[$this->hashedFileOptionKey]['dir']);
+        if ($this->hashedAssetsArray[$this->hashedFileOptionKey]['version'] !== WP_STATISTICS_VERSION) {
+            return false;
+        }
+
+        $dir = $this->hashedAssetsArray[$this->hashedFileOptionKey]['dir'] ?? '';
+
+        if (empty($dir) || !file_exists($dir)) {
+            return false;
+        }
+
+        // Legacy entries pointed into uploads/. Force regeneration so the
+        // mapping switches to the original plugin file path.
+        if (strpos($dir, Helper::get_uploads_dir()) === 0) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -248,9 +262,18 @@ class AssetNameObfuscator
      */
     private function deleteHashedFile($assetsArray, $key)
     {
-        if (!empty($assetsArray[$key]) && !empty($assetsArray[$key]['dir']) && file_exists($assetsArray[$key]['dir'])) {
-            unlink($assetsArray[$key]['dir']);
+        if (empty($assetsArray[$key]['dir']) || !file_exists($assetsArray[$key]['dir'])) {
+            return;
         }
+
+        // Only unlink files we created in the legacy uploads/ location.
+        // The current implementation stores the original plugin file path
+        // in 'dir' - we must never unlink that.
+        if (strpos($assetsArray[$key]['dir'], Helper::get_uploads_dir()) !== 0) {
+            return;
+        }
+
+        unlink($assetsArray[$key]['dir']);
     }
 
     /**
@@ -321,10 +344,38 @@ class AssetNameObfuscator
      */
     private function getHashedAssetPath($hashedFileName, $hashedAssetsArray)
     {
-        if (!empty($hashedAssetsArray)) {
-            foreach ($hashedAssetsArray as $originalPath => $info) {
-                if (isset($info['dir']) && basename($info['dir']) === $hashedFileName) {
-                    return $info['dir'];
+        if (empty($hashedAssetsArray)) {
+            return null;
+        }
+
+        foreach ($hashedAssetsArray as $originalKey => $info) {
+            // New layout: explicit hashed name stored alongside the original path.
+            // Legacy fallback: pre-upgrade entries stored the hashed name as the
+            // basename of the on-disk uploads/ copy.
+            $storedName = $info['name'] ?? (isset($info['dir']) ? basename($info['dir']) : '');
+
+            if ($storedName !== $hashedFileName) {
+                continue;
+            }
+
+            // Prefer the path stored in 'dir'. For legacy entries whose 'dir'
+            // pointed at the uploads/<hash>.js copy and that file is now gone
+            // (security plugin removed it, manual cleanup, etc), fall back to
+            // resolving the original plugin file from the option key.
+            $candidates = [];
+            if (!empty($info['dir'])) {
+                $candidates[] = $info['dir'];
+            }
+            if (!empty($originalKey)) {
+                $candidates[] = $originalKey;
+                if (!empty($this->pluginsRoot)) {
+                    $candidates[] = path_join($this->pluginsRoot, $originalKey);
+                }
+            }
+
+            foreach ($candidates as $candidate) {
+                if (file_exists($candidate)) {
+                    return $candidate;
                 }
             }
         }

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -244,7 +244,13 @@ class AssetNameObfuscator
             $this->uploadsDir = Helper::get_uploads_dir();
         }
 
-        return strpos($path, $this->uploadsDir) === 0;
+        // Anchor the prefix to a trailing slash so /…/uploads2/x.js does not
+        // match /…/uploads. Normalize $path so entries saved with mixed
+        // separators by older plugin versions still resolve correctly.
+        $uploadsRoot = wp_normalize_path(untrailingslashit($this->uploadsDir)) . '/';
+        $normalized  = wp_normalize_path($path);
+
+        return strpos($normalized, $uploadsRoot) === 0;
     }
 
     /**

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -66,20 +66,6 @@ class AssetNameObfuscator
     private $hashedFileName;
 
     /**
-     * Root of the hash files dir.
-     *
-     * @var string
-     */
-    private $hashedFilesRootDir;
-
-    /**
-     * Full dir of the hashed file.
-     *
-     * @var string
-     */
-    private $hashedFileDir;
-
-    /**
      * @param string $file Full path of the input file.
      * Pass `null` if you only want to use `deleteAllHashedFiles` and `deleteDatabaseOption` methods. (e.g. When uninstalling the plugin)
      *
@@ -132,10 +118,10 @@ class AssetNameObfuscator
 
         $this->uploadsDir = Helper::get_uploads_dir();
 
-        // Kept for backward compatibility - the proxy reads the original
-        // file directly, so these no longer drive any filesystem write.
-        $this->hashedFilesRootDir = apply_filters('wp_statistics_hashed_asset_root', $this->uploadsDir);
-        $this->hashedFileDir      = apply_filters('wp_statistics_hashed_asset_dir', path_join($this->hashedFilesRootDir, $this->hashedFileName), $this->hashedFilesRootDir, $this->hashedFileName);
+        // Fired only for back-compat with third-party hooks; the proxy reads
+        // the original plugin file directly, so the filtered values are unused.
+        apply_filters_deprecated('wp_statistics_hashed_asset_root', [$this->uploadsDir], '14.16.7', '', 'The obfuscator no longer writes a copy of the tracker into wp-content/uploads/.');
+        apply_filters_deprecated('wp_statistics_hashed_asset_dir', [path_join($this->uploadsDir, $this->hashedFileName), $this->uploadsDir, $this->hashedFileName], '14.16.7', '', 'The obfuscator no longer writes a copy of the tracker into wp-content/uploads/.');
     }
 
     /**
@@ -198,36 +184,6 @@ class AssetNameObfuscator
     public function getHashedFileName()
     {
         return $this->hashedFileName;
-    }
-
-    /**
-     * Returns hashed files root dir.
-     *
-     * @return  string
-     */
-    public function getHashedFilesRootDir()
-    {
-        return $this->hashedFilesRootDir;
-    }
-
-    /**
-     * Returns full path (DIR) of the hashed file.
-     *
-     * @return  string
-     */
-    public function getHashedFileDir()
-    {
-        return $this->hashedFileDir;
-    }
-
-    /**
-     * Returns full URL of the hashed file.
-     *
-     * @return  string
-     */
-    public function getHashedFileUrl()
-    {
-        return Helper::get_upload_url() . '/' . $this->hashedFileName;
     }
 
     /**

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -244,9 +244,12 @@ class AssetNameObfuscator
             $this->uploadsDir = Helper::get_uploads_dir();
         }
 
-        // Anchor the prefix to a trailing slash so /…/uploads2/x.js does not
-        // match /…/uploads. Normalize $path so entries saved with mixed
-        // separators by older plugin versions still resolve correctly.
+    private function isLegacyUploadsPath($path)
+    {
+        if (empty($this->uploadsDir)) {
+            $this->uploadsDir = Helper::get_uploads_dir();
+        }
+
         $uploadsRoot = wp_normalize_path(untrailingslashit($this->uploadsDir)) . '/';
         $normalized  = wp_normalize_path($path);
 

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -118,10 +118,15 @@ class AssetNameObfuscator
 
         $this->uploadsDir = Helper::get_uploads_dir();
 
-        // Fired only for back-compat with third-party hooks; the proxy reads
-        // the original plugin file directly, so the filtered values are unused.
-        apply_filters_deprecated('wp_statistics_hashed_asset_root', [$this->uploadsDir], '14.16.7', '', 'The obfuscator no longer writes a copy of the tracker into wp-content/uploads/.');
-        apply_filters_deprecated('wp_statistics_hashed_asset_dir', [path_join($this->uploadsDir, $this->hashedFileName), $this->uploadsDir, $this->hashedFileName], '14.16.7', '', 'The obfuscator no longer writes a copy of the tracker into wp-content/uploads/.');
+        // Fire deprecated filters only when something is listening, so we
+        // skip arg construction (and the global no-op) on every other call.
+        if (has_filter('wp_statistics_hashed_asset_root')) {
+            apply_filters_deprecated('wp_statistics_hashed_asset_root', [$this->uploadsDir], '14.16.7', '', 'The obfuscator no longer writes a copy of the tracker into wp-content/uploads/.');
+        }
+
+        if (has_filter('wp_statistics_hashed_asset_dir')) {
+            apply_filters_deprecated('wp_statistics_hashed_asset_dir', [path_join($this->uploadsDir, $this->hashedFileName), $this->uploadsDir, $this->hashedFileName], '14.16.7', '', 'The obfuscator no longer writes a copy of the tracker into wp-content/uploads/.');
+        }
     }
 
     /**

--- a/src/Components/AssetNameObfuscator.php
+++ b/src/Components/AssetNameObfuscator.php
@@ -12,11 +12,25 @@ use WP_STATISTICS\Option;
 class AssetNameObfuscator
 {
     /**
+     * Field names inside each option entry.
+     */
+    private const KEY_VERSION = 'version';
+    private const KEY_DIR     = 'dir';
+    private const KEY_NAME    = 'name';
+
+    /**
      * Option that contains information about all hashed files.
      *
      * @var string
      */
     private $optionName = 'hashed_assets';
+
+    /**
+     * Memoized result of Helper::get_uploads_dir() for this request.
+     *
+     * @var string
+     */
+    private $uploadsDir = '';
 
     /**
      * All hashed files.
@@ -106,26 +120,22 @@ class AssetNameObfuscator
         $this->hashedFileOptionKey = str_replace($this->pluginsRoot, '', $this->inputFileDir);
 
         if (empty($this->hashedAssetsArray[$this->hashedFileOptionKey])) {
-            $this->hashedAssetsArray[$this->hashedFileOptionKey]            = [];
-            $this->hashedAssetsArray[$this->hashedFileOptionKey]['version'] = WP_STATISTICS_VERSION;
+            $this->hashedAssetsArray[$this->hashedFileOptionKey] = [
+                self::KEY_VERSION => WP_STATISTICS_VERSION,
+            ];
         }
 
-        $this->hashedFileName     = $this->generateShortHash(WP_STATISTICS_VERSION . $this->hashedFileOptionKey);
-        $this->hashedFileName     .= '.' . pathinfo($this->inputFileDir, PATHINFO_EXTENSION);
-        $this->hashedFileName     = $this->cleanHashedFileName($this->hashedFileName);
-        $this->hashedFileName     = apply_filters('wp_statistics_hashed_asset_name', $this->hashedFileName, $this->inputFileDir);
-        $this->hashedFilesRootDir = apply_filters('wp_statistics_hashed_asset_root', Helper::get_uploads_dir());
+        $this->hashedFileName = $this->generateShortHash(WP_STATISTICS_VERSION . $this->hashedFileOptionKey);
+        $this->hashedFileName .= '.' . pathinfo($this->inputFileDir, PATHINFO_EXTENSION);
+        $this->hashedFileName = $this->cleanHashedFileName($this->hashedFileName);
+        $this->hashedFileName = apply_filters('wp_statistics_hashed_asset_name', $this->hashedFileName, $this->inputFileDir);
 
-        if (!is_dir($this->hashedFilesRootDir)) {
-            // Try to make the filtered dir if it not exists
-            if (!mkdir($this->hashedFilesRootDir, 0700)) {
-                // Revert back to default uploads folder if the filtered dir is invalid
-                $this->hashedFilesRootDir = Helper::get_uploads_dir();
-            }
-        }
+        $this->uploadsDir = Helper::get_uploads_dir();
 
-        $this->hashedFileDir = $this->isHashedFileExists() ? $this->hashedAssetsArray[$this->hashedFileOptionKey]['dir'] : path_join($this->hashedFilesRootDir, $this->hashedFileName);
-        $this->hashedFileDir = apply_filters('wp_statistics_hashed_asset_dir', $this->hashedFileDir, $this->hashedFilesRootDir, $this->hashedFileName);
+        // Kept for backward compatibility - the proxy reads the original
+        // file directly, so these no longer drive any filesystem write.
+        $this->hashedFilesRootDir = apply_filters('wp_statistics_hashed_asset_root', $this->uploadsDir);
+        $this->hashedFileDir      = apply_filters('wp_statistics_hashed_asset_dir', path_join($this->hashedFilesRootDir, $this->hashedFileName), $this->hashedFilesRootDir, $this->hashedFileName);
     }
 
     /**
@@ -142,26 +152,18 @@ class AssetNameObfuscator
     }
 
     /**
-     * Register the obfuscated mapping for this asset.
-     *
-     * The proxy in HooksManager::serveObfuscatedAsset reads the original
-     * file directly via readfile(); no on-disk copy in uploads/ is needed.
-     * Legacy entries pointing into uploads/ are cleaned up here on first
-     * run after upgrade.
-     *
-     * @return  void
+     * Records the original-path -> hashed-name mapping in the option.
      */
     private function obfuscateFileName()
     {
         if ($this->isHashedFileExists()) return;
 
-        // Remove any legacy uploads/<hash>.js artifact left behind by older
-        // versions of this class.
+        // Clean up any legacy uploads/<hash>.js copy from before the v3 refactor.
         $this->deleteHashedFile($this->hashedAssetsArray, $this->hashedFileOptionKey);
 
-        $this->hashedAssetsArray[$this->hashedFileOptionKey]['version'] = WP_STATISTICS_VERSION;
-        $this->hashedAssetsArray[$this->hashedFileOptionKey]['dir']     = $this->inputFileDir;
-        $this->hashedAssetsArray[$this->hashedFileOptionKey]['name']    = $this->hashedFileName;
+        $this->hashedAssetsArray[$this->hashedFileOptionKey][self::KEY_VERSION] = WP_STATISTICS_VERSION;
+        $this->hashedAssetsArray[$this->hashedFileOptionKey][self::KEY_DIR]     = $this->inputFileDir;
+        $this->hashedAssetsArray[$this->hashedFileOptionKey][self::KEY_NAME]    = $this->hashedFileName;
         Option::saveOptionGroup($this->hashedFileOptionKey, $this->hashedAssetsArray[$this->hashedFileOptionKey], $this->optionName);
     }
 
@@ -172,23 +174,20 @@ class AssetNameObfuscator
      */
     private function isHashedFileExists()
     {
-        if ($this->hashedAssetsArray[$this->hashedFileOptionKey]['version'] !== WP_STATISTICS_VERSION) {
+        $entry = $this->hashedAssetsArray[$this->hashedFileOptionKey] ?? [];
+
+        if (($entry[self::KEY_VERSION] ?? null) !== WP_STATISTICS_VERSION) {
             return false;
         }
 
-        $dir = $this->hashedAssetsArray[$this->hashedFileOptionKey]['dir'] ?? '';
+        $dir = $entry[self::KEY_DIR] ?? '';
 
         if (empty($dir) || !file_exists($dir)) {
             return false;
         }
 
-        // Legacy entries pointed into uploads/. Force regeneration so the
-        // mapping switches to the original plugin file path.
-        if (strpos($dir, Helper::get_uploads_dir()) === 0) {
-            return false;
-        }
-
-        return true;
+        // Force regeneration of pre-refactor entries that still point into uploads/.
+        return !$this->isLegacyUploadsPath($dir);
     }
 
     /**
@@ -262,18 +261,29 @@ class AssetNameObfuscator
      */
     private function deleteHashedFile($assetsArray, $key)
     {
-        if (empty($assetsArray[$key]['dir']) || !file_exists($assetsArray[$key]['dir'])) {
-            return;
-        }
+        $dir = $assetsArray[$key][self::KEY_DIR] ?? '';
 
         // Only unlink files we created in the legacy uploads/ location.
-        // The current implementation stores the original plugin file path
-        // in 'dir' - we must never unlink that.
-        if (strpos($assetsArray[$key]['dir'], Helper::get_uploads_dir()) !== 0) {
+        // The current 'dir' stores the original plugin file path, which must never be removed.
+        if (empty($dir) || !file_exists($dir) || !$this->isLegacyUploadsPath($dir)) {
             return;
         }
 
-        unlink($assetsArray[$key]['dir']);
+        unlink($dir);
+    }
+
+    /**
+     * Whether the given path is inside the legacy uploads/ root used by the
+     * v1 obfuscator. Anything outside it is treated as belonging to the
+     * plugin and never written or deleted by this class.
+     */
+    private function isLegacyUploadsPath($path)
+    {
+        if (empty($this->uploadsDir)) {
+            $this->uploadsDir = Helper::get_uploads_dir();
+        }
+
+        return strpos($path, $this->uploadsDir) === 0;
     }
 
     /**
@@ -349,31 +359,22 @@ class AssetNameObfuscator
         }
 
         foreach ($hashedAssetsArray as $originalKey => $info) {
-            // New layout: explicit hashed name stored alongside the original path.
-            // Legacy fallback: pre-upgrade entries stored the hashed name as the
-            // basename of the on-disk uploads/ copy.
-            $storedName = $info['name'] ?? (isset($info['dir']) ? basename($info['dir']) : '');
-
-            if ($storedName !== $hashedFileName) {
-                continue;
-            }
-
-            // Prefer the path stored in 'dir'. For legacy entries whose 'dir'
-            // pointed at the uploads/<hash>.js copy and that file is now gone
-            // (security plugin removed it, manual cleanup, etc), fall back to
-            // resolving the original plugin file from the option key.
-            $candidates = [];
-            if (!empty($info['dir'])) {
-                $candidates[] = $info['dir'];
-            }
-            if (!empty($originalKey)) {
-                $candidates[] = $originalKey;
-                if (!empty($this->pluginsRoot)) {
-                    $candidates[] = path_join($this->pluginsRoot, $originalKey);
+            // Fast path: post-refactor entries store the hashed name explicitly
+            // and 'dir' is the original plugin file (always present on disk).
+            if (isset($info[self::KEY_NAME]) && $info[self::KEY_NAME] === $hashedFileName) {
+                if (!empty($info[self::KEY_DIR]) && file_exists($info[self::KEY_DIR])) {
+                    return $info[self::KEY_DIR];
                 }
             }
 
-            foreach ($candidates as $candidate) {
+            // Legacy entries stored the hashed name as basename of an uploads/
+            // copy that may now be gone. Recover by resolving the original
+            // plugin file from the option key.
+            if (empty($info[self::KEY_DIR]) || basename($info[self::KEY_DIR]) !== $hashedFileName) {
+                continue;
+            }
+
+            foreach ($this->legacyFallbackCandidates($originalKey, $info[self::KEY_DIR]) as $candidate) {
                 if (file_exists($candidate)) {
                     return $candidate;
                 }
@@ -381,6 +382,25 @@ class AssetNameObfuscator
         }
 
         return null;
+    }
+
+    /**
+     * @param string $originalKey
+     * @param string $dir
+     * @return string[]
+     */
+    private function legacyFallbackCandidates($originalKey, $dir)
+    {
+        $candidates = [$dir];
+
+        if (!empty($originalKey)) {
+            $candidates[] = $originalKey;
+            if (!empty($this->pluginsRoot)) {
+                $candidates[] = path_join($this->pluginsRoot, $originalKey);
+            }
+        }
+
+        return $candidates;
     }
 
     /**

--- a/src/Components/TrackingResponse.php
+++ b/src/Components/TrackingResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP_Statistics\Components;
+
+/**
+ * Response headers shared by every tracking endpoint (custom event,
+ * hit record, REST /hit). Keeps the URLs out of search-engine indexes
+ * and out of reverse-proxy / CDN caches.
+ *
+ * @link https://wordpress.org/support/topic/request-for-cloudflare-html-caching-compatibility/
+ */
+class TrackingResponse
+{
+    /**
+     * @return array<string,string>
+     */
+    public static function getHeaders()
+    {
+        return [
+            'X-Robots-Tag'  => 'noindex, nofollow',
+            'Cache-Control' => 'no-cache',
+        ];
+    }
+
+    /**
+     * Emit headers via header(). For REST handlers, pass getHeaders()
+     * to $response->set_headers() instead.
+     */
+    public static function sendHeaders()
+    {
+        if (headers_sent()) {
+            return;
+        }
+
+        foreach (self::getHeaders() as $name => $value) {
+            header($name . ': ' . $value, true);
+        }
+    }
+}

--- a/src/Service/Admin/Optimization/OptimizationActions.php
+++ b/src/Service/Admin/Optimization/OptimizationActions.php
@@ -277,8 +277,6 @@ class OptimizationActions
             ];
 
             $method   = Option::get('geoip_location_detection_method', 'maxmind');
-            $method   = false;
-
             $provider = $providerMap[$method] ?? $providerMap['maxmind'];
 
             // First download/update the GeoIP database

--- a/src/Service/Analytics/AnalyticsController.php
+++ b/src/Service/Analytics/AnalyticsController.php
@@ -21,6 +21,8 @@ class AnalyticsController
             return;
         }
 
+        Helper::sendTrackingResponseHeaders();
+
         try {
             $this->checkSignature();
             Helper::validateHitRequest();

--- a/src/Service/Analytics/AnalyticsController.php
+++ b/src/Service/Analytics/AnalyticsController.php
@@ -5,6 +5,7 @@ namespace WP_Statistics\Service\Analytics;
 use Exception;
 use WP_STATISTICS\Helper;
 use WP_STATISTICS\Hits;
+use WP_Statistics\Components\TrackingResponse;
 use WP_Statistics\Utils\Request;
 use WP_Statistics\Utils\Signature;
 
@@ -21,7 +22,7 @@ class AnalyticsController
             return;
         }
 
-        Helper::sendTrackingResponseHeaders();
+        TrackingResponse::sendHeaders();
 
         try {
             $this->checkSignature();

--- a/src/Service/Analytics/DeviceDetection/UserAgentService.php
+++ b/src/Service/Analytics/DeviceDetection/UserAgentService.php
@@ -46,7 +46,7 @@ class UserAgentService
      */
     public function getBrowser()
     {
-        return $this->deviceDetector ? $this->deviceDetector->getClient('name') : null;
+        return $this->deviceDetector ? self::sanitizeDetectorValue($this->deviceDetector->getClient('name')) : null;
     }
 
     /**
@@ -56,7 +56,7 @@ class UserAgentService
      */
     public function getPlatform()
     {
-        return $this->deviceDetector ? $this->deviceDetector->getOs('name') : null;
+        return $this->deviceDetector ? self::sanitizeDetectorValue($this->deviceDetector->getOs('name')) : null;
     }
 
     /**
@@ -76,7 +76,7 @@ class UserAgentService
      */
     public function getDevice()
     {
-        return $this->deviceDetector ? $this->deviceDetector->getDeviceName() : null;
+        return $this->deviceDetector ? self::sanitizeDetectorValue($this->deviceDetector->getDeviceName()) : null;
     }
 
     /**
@@ -102,9 +102,27 @@ class UserAgentService
             }
 
             $model = trim($brand . ' ' . $device);
-        }      
+        }
 
-        return $model ?? null;
+        return self::sanitizeDetectorValue($model);
+    }
+
+    /**
+     * DeviceDetector's fallback regexes can capture raw bytes from the
+     * User-Agent header, so restrict stored values to a safe subset before
+     * they reach DB storage, admin reports, REST, or exports.
+     */
+    public static function sanitizeDetectorValue($value)
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        $value = wp_strip_all_tags((string) $value);
+        $value = preg_replace('/[^\p{L}\p{N}\s._\-\/+()&\']/u', '', $value);
+        $value = trim(preg_replace('/\s+/', ' ', (string) $value));
+
+        return $value;
     }
 
     /**

--- a/src/Service/CustomEvent/CustomEventActions.php
+++ b/src/Service/CustomEvent/CustomEventActions.php
@@ -5,6 +5,7 @@ use Exception;
 use WP_Statistics\Models\EventsModel;
 use WP_Statistics\Utils\Request;
 use WP_Statistics\Components\Ajax;
+use WP_Statistics\Components\TrackingResponse;
 use WP_STATISTICS\Exclusion;
 use WP_Statistics\Service\Analytics\VisitorProfile;
 
@@ -20,7 +21,7 @@ class CustomEventActions
 
     public function insertCustomEvent()
     {
-        \WP_STATISTICS\Helper::sendTrackingResponseHeaders();
+        TrackingResponse::sendHeaders();
 
         try {
             $nonce = Request::get('nonce');

--- a/src/Service/CustomEvent/CustomEventActions.php
+++ b/src/Service/CustomEvent/CustomEventActions.php
@@ -20,6 +20,8 @@ class CustomEventActions
 
     public function insertCustomEvent()
     {
+        \WP_STATISTICS\Helper::sendTrackingResponseHeaders();
+
         try {
             $nonce = Request::get('nonce');
 

--- a/src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php
+++ b/src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php
@@ -5,10 +5,10 @@ namespace WP_Statistics\Service\Database\Migrations\BackgroundProcess\Jobs;
 use WP_Statistics\Abstracts\BaseBackgroundProcess;
 use WP_Statistics\Decorators\VisitorDecorator;
 use WP_STATISTICS\Menus;
+use WP_STATISTICS\Option;
 use WP_Statistics\Models\VisitorsModel;
 use WP_Statistics\Service\Admin\NoticeHandler\Notice;
 use WP_Statistics\Service\Geolocation\GeolocationFactory;
-use WP_Statistics\Service\Geolocation\Provider\MaxmindGeoIPProvider;
 
 class IncompleteGeoIpUpdater extends BaseBackgroundProcess
 {
@@ -63,6 +63,15 @@ class IncompleteGeoIpUpdater extends BaseBackgroundProcess
      */
     protected function task($item)
     {
+        // Cloudflare geolocation only resolves from live request headers, which
+        // are absent in queue/cron context. Skip rather than fall back to
+        // MaxMind, which would silently re-download GeoLite2-City.mmdb on
+        // sites that explicitly opted out of MaxMind.
+        if (Option::get('geoip_location_detection_method', 'maxmind') === 'cf') {
+            $this->setProcessed($item['visitors']);
+            return false;
+        }
+
         $visitors     = $item['visitors'];
         $visitorModel = new VisitorsModel();
 
@@ -79,7 +88,7 @@ class IncompleteGeoIpUpdater extends BaseBackgroundProcess
                 continue;
             }
 
-            $location = GeolocationFactory::getLocation($visitor->getIP(), MaxmindGeoIPProvider::class);
+            $location = GeolocationFactory::getLocation($visitor->getIP());
 
             $visitorModel->updateVisitor($visitorId, [
                 'location'  => $location['country_code'],

--- a/src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php
+++ b/src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php
@@ -64,16 +64,12 @@ class IncompleteGeoIpUpdater extends BaseBackgroundProcess
      */
     protected function task($item)
     {
-        // Cloudflare geolocation depends on HTTP_CF_* headers from a live
-        // request, which are absent in queue/cron context. The job has always
-        // used MaxMind as the server-side fallback for backfill, including on
-        // sites that later switched to CF mode while still holding the
-        // GeoLite2-City.mmdb file from before. Keep that behavior, but if the
-        // site is on CF mode and the database file is no longer on disk, skip
-        // rather than let MaxmindGeoIPProvider::initializeReader() silently
-        // re-download it.
-        if (Option::get('geoip_location_detection_method', 'maxmind') === 'cf'
-            && !(new MaxmindGeoIPProvider())->isDatabaseExist()) {
+        // CF headers are not available in cron, so this job uses MaxMind as
+        // the server-side fallback. On cf-mode sites without the mmdb on
+        // disk, skip rather than backfill rows with default-location data
+        // (issue #1093).
+        if (Option::get('geoip_location_detection_method', 'maxmind') === 'cf' &&
+            !(new MaxmindGeoIPProvider())->isDatabaseExist()) {
             $this->setProcessed($item['visitors']);
             return false;
         }

--- a/src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php
+++ b/src/Service/Database/Migrations/BackgroundProcess/Jobs/IncompleteGeoIpUpdater.php
@@ -9,6 +9,7 @@ use WP_STATISTICS\Option;
 use WP_Statistics\Models\VisitorsModel;
 use WP_Statistics\Service\Admin\NoticeHandler\Notice;
 use WP_Statistics\Service\Geolocation\GeolocationFactory;
+use WP_Statistics\Service\Geolocation\Provider\MaxmindGeoIPProvider;
 
 class IncompleteGeoIpUpdater extends BaseBackgroundProcess
 {
@@ -63,11 +64,16 @@ class IncompleteGeoIpUpdater extends BaseBackgroundProcess
      */
     protected function task($item)
     {
-        // Cloudflare geolocation only resolves from live request headers, which
-        // are absent in queue/cron context. Skip rather than fall back to
-        // MaxMind, which would silently re-download GeoLite2-City.mmdb on
-        // sites that explicitly opted out of MaxMind.
-        if (Option::get('geoip_location_detection_method', 'maxmind') === 'cf') {
+        // Cloudflare geolocation depends on HTTP_CF_* headers from a live
+        // request, which are absent in queue/cron context. The job has always
+        // used MaxMind as the server-side fallback for backfill, including on
+        // sites that later switched to CF mode while still holding the
+        // GeoLite2-City.mmdb file from before. Keep that behavior, but if the
+        // site is on CF mode and the database file is no longer on disk, skip
+        // rather than let MaxmindGeoIPProvider::initializeReader() silently
+        // re-download it.
+        if (Option::get('geoip_location_detection_method', 'maxmind') === 'cf'
+            && !(new MaxmindGeoIPProvider())->isDatabaseExist()) {
             $this->setProcessed($item['visitors']);
             return false;
         }
@@ -88,7 +94,7 @@ class IncompleteGeoIpUpdater extends BaseBackgroundProcess
                 continue;
             }
 
-            $location = GeolocationFactory::getLocation($visitor->getIP());
+            $location = GeolocationFactory::getLocation($visitor->getIP(), MaxmindGeoIPProvider::class);
 
             $visitorModel->updateVisitor($visitorId, [
                 'location'  => $location['country_code'],

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -80,8 +80,14 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
         }
 
         try {
-            // Check if the GeoIP database exists and download it immediately.
-            if (!$this->isDatabaseExist() && !Env::isLocal()) {
+            // Auto-download only when MaxMind is the user's chosen provider.
+            // On dbip or cf mode this code path can still be reached (e.g.
+            // background backfill that forces MaxMind), but silently
+            // re-downloading the database for users who explicitly opted out
+            // is the regression behind issue #1093.
+            if (!$this->isDatabaseExist()
+                && !Env::isLocal()
+                && Option::get('geoip_location_detection_method', 'maxmind') === 'maxmind') {
                 $this->downloadDatabase();
 
                 throw new Exception('GeoIP database not found. Attempting to download...');

--- a/tests/integration/Test_UserAgentService.php
+++ b/tests/integration/Test_UserAgentService.php
@@ -141,4 +141,174 @@ class Test_UserAgentService extends WP_UnitTestCase
 
         $this->assertEquals('UNK', $userAgentService->getBrowser());
     }
+
+    public function test_sanitize_preserves_null_and_empty()
+    {
+        $this->assertNull(UserAgentService::sanitizeDetectorValue(null));
+        $this->assertSame('', UserAgentService::sanitizeDetectorValue(''));
+    }
+
+    public function test_sanitize_keeps_common_browser_names()
+    {
+        $this->assertSame('Chrome', UserAgentService::sanitizeDetectorValue('Chrome'));
+        $this->assertSame('Microsoft Edge', UserAgentService::sanitizeDetectorValue('Microsoft Edge'));
+        $this->assertSame('Samsung Browser', UserAgentService::sanitizeDetectorValue('Samsung Browser'));
+    }
+
+    public function test_sanitize_keeps_allowed_punctuation()
+    {
+        $this->assertSame('Opera Mini/Beta', UserAgentService::sanitizeDetectorValue('Opera Mini/Beta'));
+        $this->assertSame('UC Browser (HD)', UserAgentService::sanitizeDetectorValue('UC Browser (HD)'));
+        $this->assertSame('Chrome-Mobile_v2.1', UserAgentService::sanitizeDetectorValue('Chrome-Mobile_v2.1'));
+    }
+
+    public function test_sanitize_keeps_unicode_letters()
+    {
+        $this->assertSame('Yandex Браузер', UserAgentService::sanitizeDetectorValue('Yandex Браузер'));
+    }
+
+    public function test_sanitize_strips_html_tags()
+    {
+        $this->assertSame('Chrome', UserAgentService::sanitizeDetectorValue('<script>alert(1)</script>Chrome'));
+        $this->assertSame('Firefox', UserAgentService::sanitizeDetectorValue('<img src=x onerror=alert(1)>Firefox'));
+    }
+
+    public function test_sanitize_neutralizes_attribute_breakers()
+    {
+        $clean = UserAgentService::sanitizeDetectorValue('evil" onload="alert(document.domain)');
+
+        $this->assertStringNotContainsString('"', $clean);
+        $this->assertStringNotContainsString('<', $clean);
+        $this->assertStringNotContainsString('>', $clean);
+        $this->assertStringNotContainsString('=', $clean);
+
+        $this->assertSame("abc'", UserAgentService::sanitizeDetectorValue("abc'\"<>`"));
+        $this->assertSame('abc1', UserAgentService::sanitizeDetectorValue("abc=1;"));
+    }
+
+    public function test_sanitize_strips_control_characters_and_collapses_whitespace()
+    {
+        $this->assertSame('Chrome', UserAgentService::sanitizeDetectorValue("Chrome\x00\x01\x1f"));
+        $this->assertSame('Chrome Mobile', UserAgentService::sanitizeDetectorValue("  Chrome    Mobile  "));
+        $this->assertSame('Chrome Mobile', UserAgentService::sanitizeDetectorValue("Chrome\n\nMobile"));
+    }
+
+    /**
+     * End-to-end: the exact payload from the reported vulnerability must
+     * not produce a stored browser name containing attribute-breaking
+     * characters, so admin templates can't render an injected handler.
+     */
+    public function test_crafted_user_agent_is_sanitized_before_storage()
+    {
+        $_SERVER['HTTP_USER_AGENT'] = 'evil" onload="alert(document.domain)/1.2 (iPhone; iOS 16.0; Scale/3.00)';
+
+        $userAgentService = new UserAgentService();
+        $browser          = (string) $userAgentService->getBrowser();
+
+        $this->assertStringNotContainsString('"', $browser);
+        $this->assertStringNotContainsString('<', $browser);
+        $this->assertStringNotContainsString('>', $browser);
+        $this->assertStringNotContainsString('=', $browser);
+    }
+
+    /**
+     * Sanitizer must be a no-op for the browser/OS names that show up in
+     * real traffic — regression guard so future tightening doesn't quietly
+     * mangle mainstream labels.
+     *
+     * @dataProvider realWorldUserAgentProvider
+     */
+    public function test_sanitize_is_noop_for_real_user_agents($userAgent, $expectedBrowser, $expectedPlatform)
+    {
+        $_SERVER['HTTP_USER_AGENT'] = $userAgent;
+
+        $service = new UserAgentService();
+
+        $this->assertSame($expectedBrowser, $service->getBrowser());
+        $this->assertSame($expectedPlatform, $service->getPlatform());
+    }
+
+    public function realWorldUserAgentProvider()
+    {
+        return [
+            'Chrome on Windows' => [
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                'Chrome',
+                'Windows',
+            ],
+            'Firefox on macOS' => [
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0',
+                'Firefox',
+                'Mac',
+            ],
+            'Safari on iPhone' => [
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1',
+                'Mobile Safari',
+                'iOS',
+            ],
+            'Edge on Windows' => [
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0',
+                'Microsoft Edge',
+                'Windows',
+            ],
+            'Chrome on Android' => [
+                'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36',
+                'Chrome Mobile',
+                'Android',
+            ],
+            'Samsung Internet' => [
+                'Mozilla/5.0 (Linux; Android 13; SAMSUNG SM-G998B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36',
+                'Samsung Browser',
+                'Android',
+            ],
+            'Opera on Windows' => [
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36 OPR/102.0.0.0',
+                'Opera',
+                'Windows',
+            ],
+            'Yandex on Android' => [
+                'Mozilla/5.0 (Linux; arm_64; Android 11; SM-A515F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/105.0.0.0 YaBrowser/22.11.5.93.00 SA/3 Mobile Safari/537.36',
+                'Yandex Browser',
+                'Android',
+            ],
+            'IE 11' => [
+                'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko',
+                'Internet Explorer',
+                'Windows',
+            ],
+        ];
+    }
+
+    /**
+     * Brand/OS labels that contain `&` or `'` must pass through unchanged
+     * so stats aren't split across multiple buckets (e.g. AT&T vs ATT).
+     * Both characters are safe inside double-quoted HTML attributes, and
+     * the output sinks already apply esc_attr/esc_html.
+     */
+    public function test_sanitize_preserves_ampersand_and_apostrophe_in_labels()
+    {
+        $this->assertSame('AT&T', UserAgentService::sanitizeDetectorValue('AT&T'));
+        $this->assertSame('Barnes & Noble', UserAgentService::sanitizeDetectorValue('Barnes & Noble'));
+        $this->assertSame("BYJU'S", UserAgentService::sanitizeDetectorValue("BYJU'S"));
+        $this->assertSame('Krüger&Matz', UserAgentService::sanitizeDetectorValue('Krüger&Matz'));
+    }
+
+    /**
+     * Extremely niche labels with `!` / `^` still get normalized. Pinned
+     * here so we notice if the character class ever changes.
+     */
+    public function test_sanitize_normalizes_exclamation_and_caret()
+    {
+        $this->assertSame('Yahoo Japan Browser', UserAgentService::sanitizeDetectorValue('Yahoo! Japan Browser'));
+        $this->assertSame('FRITZOS', UserAgentService::sanitizeDetectorValue('FRITZ!OS'));
+        $this->assertSame('Symbian3', UserAgentService::sanitizeDetectorValue('Symbian^3'));
+    }
+
+    public function test_sanitize_preserves_unicode_letters_in_labels()
+    {
+        $this->assertSame('Caixa Mágica', UserAgentService::sanitizeDetectorValue('Caixa Mágica'));
+        $this->assertSame('Arçelik', UserAgentService::sanitizeDetectorValue('Arçelik'));
+        $this->assertSame('ALDI SÜD', UserAgentService::sanitizeDetectorValue('ALDI SÜD'));
+        $this->assertSame('Türk Telekom', UserAgentService::sanitizeDetectorValue('Türk Telekom'));
+    }
 }

--- a/tests/unit/Test_AssetNameObfuscator.php
+++ b/tests/unit/Test_AssetNameObfuscator.php
@@ -62,14 +62,19 @@ class Test_AssetNameObfuscator extends WP_UnitTestCase
     {
         $option = get_option('wp_statistics_hashed_assets');
         $this->assertIsArray($option);
-        $this->assertNotEmpty($option);
 
-        $entry = reset($option);
+        $entry = null;
+        foreach ($option as $candidate) {
+            if (is_array($candidate) && isset($candidate['name']) && $candidate['name'] === $this->obfuscator->getHashedFileName()) {
+                $entry = $candidate;
+                break;
+            }
+        }
 
+        $this->assertNotNull($entry, 'Expected an entry for the test file in the hashed_assets option.');
         $this->assertArrayHasKey('dir', $entry);
         $this->assertArrayHasKey('name', $entry);
         $this->assertSame($this->testFile, $entry['dir']);
-        $this->assertSame($this->obfuscator->getHashedFileName(), $entry['name']);
     }
 
     /**

--- a/tests/unit/Test_AssetNameObfuscator.php
+++ b/tests/unit/Test_AssetNameObfuscator.php
@@ -54,35 +54,33 @@ class Test_AssetNameObfuscator extends WP_UnitTestCase
     }
 
     /**
-     * Test if hashed file directory is set correctly.
+     * The mapping stores the original input file path under 'dir' and
+     * the hashed name under 'name'. The proxy reads the original file
+     * directly, so no copy is written to uploads/.
      */
-    public function test_get_hashed_file_dir()
+    public function test_option_entry_layout()
     {
-        $hashedFileDir = $this->obfuscator->getHashedFileDir();
-        $this->assertNotEmpty($hashedFileDir);
-        $this->assertDirectoryExists(dirname($hashedFileDir));
+        $option = get_option('wp_statistics_hashed_assets');
+        $this->assertIsArray($option);
+        $this->assertNotEmpty($option);
+
+        $entry = reset($option);
+
+        $this->assertArrayHasKey('dir', $entry);
+        $this->assertArrayHasKey('name', $entry);
+        $this->assertSame($this->testFile, $entry['dir']);
+        $this->assertSame($this->obfuscator->getHashedFileName(), $entry['name']);
     }
 
     /**
-     * Test if the hashed file is created.
+     * No copy of the input file should land in uploads/.
      */
-    public function test_hashed_file_creation()
+    public function test_no_copy_written_to_uploads()
     {
-        $hashedFileDir = $this->obfuscator->getHashedFileDir();
-        $this->assertFileExists($hashedFileDir);
-    }
+        $uploadsDir   = Helper::get_uploads_dir();
+        $hashedInUploads = path_join($uploadsDir, $this->obfuscator->getHashedFileName());
 
-    /**
-     * Test deletion of all hashed files.
-     */
-    public function test_delete_all_hashed_files()
-    {
-        $hashedFileDir = $this->obfuscator->getHashedFileDir();
-        $this->assertFileExists($hashedFileDir);
-
-        $this->obfuscator->deleteAllHashedFiles();
-
-        $this->assertFileDoesNotExist($hashedFileDir);
+        $this->assertFileDoesNotExist($hashedInUploads);
     }
 
     /**

--- a/views/components/session-details.php
+++ b/views/components/session-details.php
@@ -83,14 +83,14 @@ use WP_Statistics\Components\View;
     <div class="wps-visitor__visitors-detail--row">
         <span><?php esc_html_e('City', 'wp-statistics'); ?></span>
         <div class="wps-ellipsis-parent">
-            <span title="<?php echo Admin_Template::unknownToNotSet($visitor->getLocation()->getCity()) ?>"><?php echo Admin_Template::unknownToNotSet($visitor->getLocation()->getCity()) ?></span>
+            <span title="<?php echo esc_attr(Admin_Template::unknownToNotSet($visitor->getLocation()->getCity())) ?>"><?php echo esc_html(Admin_Template::unknownToNotSet($visitor->getLocation()->getCity())) ?></span>
         </div>
     </div>
 
     <div class="wps-visitor__visitors-detail--row">
         <span><?php esc_html_e('Region', 'wp-statistics'); ?></span>
         <div class="wps-ellipsis-parent">
-            <span title="<?php echo Admin_Template::unknownToNotSet($visitor->getLocation()->getRegion()) ?>"><?php echo Admin_Template::unknownToNotSet($visitor->getLocation()->getRegion()) ?></span>
+            <span title="<?php echo esc_attr(Admin_Template::unknownToNotSet($visitor->getLocation()->getRegion())) ?>"><?php echo esc_html(Admin_Template::unknownToNotSet($visitor->getLocation()->getRegion())) ?></span>
         </div>
     </div>
 

--- a/wp-statistics.php
+++ b/wp-statistics.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wp-statistics.com/
  * GitHub Plugin URI: https://github.com/wp-statistics/wp-statistics
  * Description: Get website traffic insights with GDPR/CCPA compliant, privacy-friendly analytics. Includes visitor data, stunning graphs, and no data sharing.
- * Version: 14.16.6
+ * Version: 14.16.7
  * Author: VeronaLabs
  * Author URI: https://veronalabs.com/
  * Text Domain: wp-statistics
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/includes/defines.php';
 
 # Set another useful plugin define.
-define('WP_STATISTICS_VERSION', '14.16.6');
+define('WP_STATISTICS_VERSION', '14.16.7');
 
 # Load Plugin
 if (!class_exists('WP_Statistics')) {


### PR DESCRIPTION
## Summary
- Hardened escaping and sanitization in device reports.
- Tracking endpoints now send noindex and no-cache headers to prevent "ghost pages" in Google Search Console.
- Stopped GeoLite2-City background downloads on Cloudflare IP Geolocation sites (issue #1093).
- "Bypass Ad Blockers" no longer copies the tracker into wp-content/uploads/, improving compatibility with hardened hosting.
- **Run Migration** button stays clickable during an active migration so stuck queues can be recovered from the UI.
- Deprecated `wp_statistics_hashed_asset_root` and `wp_statistics_hashed_asset_dir` filters; back-compat preserved.

## Test plan
- [ ] `composer test` — full PHPUnit suite green (112 tests).
- [ ] Verify device-report templates render escaped strings for adversarial UA values.
- [ ] Verify `/wp-json/wp-statistics/v2/hit`, hit-record AJAX, and custom-event AJAX responses include `X-Robots-Tag: noindex, nofollow` and `Cache-Control: no-cache`.
- [ ] Switch geolocation to Cloudflare, delete `GeoLite2-City.mmdb`, confirm it does not re-download in background.
- [ ] Enable Bypass Ad Blockers, confirm no `*.js` copy appears in `wp-content/uploads/`.
- [ ] Trigger a long migration on the Data Migrations screen and confirm Run Migration stays clickable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 14.16.7

* **Bug Fixes**
  * Enhanced output escaping and sanitization across device reports for improved security.
  * Fixed "Bypass Ad Blockers" directory write functionality.
  * Improved device name and location data sanitization.

* **Enhancements**
  * Run Migration button now remains active and clickable during ongoing migrations.
  * GeoLite2 re-download prevention when using Cloudflare geolocation mode.
  * Optimized internal tracking endpoint header handling.

* **Deprecations**
  * Deprecated certain asset configuration filters; updates may be required for custom implementations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wp-statistics/wp-statistics/pull/1095)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->