### PR TITLE
Fix: site-wide historical baseline added to every post's Total Views (Content Analytics)

### DIFF
--- a/src/Models/HistoricalModel.php
+++ b/src/Models/HistoricalModel.php
@@ -123,6 +123,19 @@ class HistoricalModel
             return $this->resourceId;
         }
 
+        // Content Analytics (and ViewsModel::countViews) map `post_id` to
+        // `resource_id`, so a single post/page/CPT arrives here as
+        // `resource_id` with no `post_id`. Without this branch getResourceId()
+        // returns null, the page_id/uri filters in getViews() drop out, and
+        // the query collapses to `category = 'visits'` - adding the site-wide
+        // historical baseline to every resource's total. (#15137)
+        if (!empty($args['resource_id'])) {
+            $this->resourceId = $args['resource_id'];
+            $this->type       = 'post';
+
+            return $this->resourceId;
+        }
+
         $this->resourceId = null;
         $this->type       = null;
 

--- a/src/Models/HistoricalModel.php
+++ b/src/Models/HistoricalModel.php
@@ -96,6 +96,7 @@ class HistoricalModel
      * @type int $post_id Optional. Post ID to retrieve.
      * @type int $term Optional. Term ID to retrieve.
      * @type int $author_id Optional. Author ID to retrieve.
+     * @type int $resource_id Optional. Resource (post/page/CPT) ID to retrieve; alias of $post_id used by Content Analytics.
      * }
      *
      * @return int|null The ID of the first found resource, or null if no resource ID specified


### PR DESCRIPTION
## Problem
On the Content Analytics single-resource screen, every post/page/CPT showed an inflated **Total Views** (e.g. "1M") while the Today / Yesterday / 7d / 28d windows correctly read the real recent numbers, and Total Visitors was correct. Reported in helpdesk #15137 (customer baseline happened to be ~1,053,661 views, so every post rounded to "1M").

## Root cause
- Content Analytics maps `post_id => resource_id` and `ViewsModel::countViews()` adds `historicalModel->getViews($args)`, passing the resource as **`resource_id`** (no `post_id`).
- `HistoricalModel::getResourceId()` only inspected `post_id` / `term` / `author_id`, so it returned `null`; `getResourceUri()` then returned `null` too.
- In `getViews()` the query is built with `where('page_id','=',null)` and `where('uri','=',null)`. `Query::where()` skips empty non-numeric values, so both filters dropped out and the query collapsed to `SELECT SUM(value) FROM historical WHERE category = 'visits'` - i.e. the **site-wide historical baseline added to every resource**.
- Visitors was unaffected because `getVisitors()`/`parseVisitorsArgs()` bail to 0 when a non-allowlisted arg (like `resource_id`) is present; `parseViewsArgs()` has no such guard.

## Fix
Recognize `resource_id` in `HistoricalModel::getResourceId()` (as a post-type resource), added after the `term`/`author_id` checks so taxonomy/author paths are untouched. Per-resource historical views are now filtered to the resource; site-wide totals (no resource id) still return the global `visits` baseline.

## Verification
- Confirmed on the reporter's staging data: post with no historical row previously returned the global baseline (~1.05M); with the fix it filters to the post (0, or the post's own `uri` historical row).
- `php -l` clean. Dev build (14.16.8.1) sent to the customer for confirmation.

Ref: helpdesk #15137