### PR TITLE
Add WP Statistics v15 Early Access callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 # WP Statistics – Simple, privacy-friendly Google Analytics alternative
 
+> 🚀 **WP Statistics v15 Early Access is open** — a major rewrite, and we'd love your feedback. Developers and active users welcome. **[Want in? Comment here →](https://github.com/wp-statistics/wp-statistics/discussions/1098)**
+
 ## Requirements
 - Requires at least: 5.0
 - Tested up to: 6.7


### PR DESCRIPTION
Adds a one-line callout near the top of the README linking to the v15 Early Access sign-up discussion (#1098). Easy to revert when Early Access ends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added early-access announcement for WP Statistics v15 to the README, positioned prominently at the top. The announcement invites developers and active users to participate in testing the upcoming version and share their feedback through GitHub discussions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->