### PR TITLE
Fix E_STRICT deprecation notice on PHP 8.4+

### DIFF
--- a/src/Service/Logger/AbstractLoggerProvider.php
+++ b/src/Service/Logger/AbstractLoggerProvider.php
@@ -42,7 +42,10 @@ abstract class AbstractLoggerProvider implements LoggerServiceProviderInterface
         // Notices
         E_NOTICE => 'notice',
         E_USER_NOTICE => 'notice',
-        E_STRICT => 'notice',
+        // 2048 is the integer value of the E_STRICT constant, which is deprecated
+        // as of PHP 8.4 and emits a deprecation notice when referenced by name.
+        // Using the literal value keeps the mapping without triggering that notice.
+        2048 => 'notice',
 
         // Deprecation notices
         E_DEPRECATED => 'deprecated',


### PR DESCRIPTION
## Summary

The logger severity map in `AbstractLoggerProvider` referenced the `E_STRICT` constant by name. As of **PHP 8.4** that constant is deprecated, so evaluating the map emits a `Constant E_STRICT is deprecated` notice (reported in #1100 on PHP 8.5).

On its own it is only a notice. But on servers with `display_errors` enabled, that notice can be printed into the tracker hit response, break its JSON, and cause visits to silently not record. So it is worth removing.

## Change

Replace `E_STRICT => 'notice'` with `2048 => 'notice'` (2048 is the integer value of `E_STRICT`). The mapping is behaviourally identical, but no deprecated constant is referenced, so the notice is gone on PHP 8.4+.

`getErrorSeverity()` already falls back to `'unknown'` for unmapped codes, so there is no functional risk.

## Testing

- `php -l` passes.
- Confirmed `E_STRICT === 2048`, so the map entry is unchanged.
- No remaining literal `E_STRICT` references in `src/` or `includes/`.

Ref: #1100