### PR TITLE
Improve metabox AJAX access handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.10 - 2026-07-23
+- **Enhancement:** General security hardening and internal improvements in the admin area.
+
 14.16.9 - 2026-07-21
 - **Fix:** Content Analytics no longer adds the site-wide historical baseline into each post's Total Views, so per-post totals are accurate again (issue [#1097](https://github.com/wp-statistics/wp-statistics/issues/1097)).
 - **Fix:** Prevented a fatal error on admin load when license validation fails or the license key is empty.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wp-statistics.com/donate/
 Tags: analytics, google analytics, insights, stats, site visitors
 Requires at least: 6.6
 Tested up to: 7.0
-Stable tag: 14.16.9
+Stable tag: 14.16.10
 Requires PHP: 7.4
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -146,6 +146,9 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.10 - 2026-07-23 =
+- **Enhancement:** General security hardening and internal improvements in the admin area.
+
 = 14.16.9 - 2026-07-21 =
 - **Fix:** Content Analytics no longer adds the site-wide historical baseline into each post's Total Views, so per-post totals are accurate again (issue [#1097](https://github.com/wp-statistics/wp-statistics/issues/1097)).
 - **Fix:** Prevented a fatal error on admin load when license validation fails or the license key is empty.

--- a/src/Abstracts/BaseMetabox.php
+++ b/src/Abstracts/BaseMetabox.php
@@ -220,6 +220,12 @@ abstract class BaseMetabox
             throw new \Exception('Invalid nonce.');
         }
 
+        if (!User::Access('read')) {
+            wp_send_json_error([
+                'message' => esc_html__('Unauthorized.', 'wp-statistics')
+            ], 403);
+        }
+
         $this->storeFilters();
 
         $response = [
@@ -243,8 +249,7 @@ abstract class BaseMetabox
      */
     public function register()
     {
-        $userCapability = Option::get('read_capability');
-        $screens        = $this->getScreen();
+        $screens = $this->getScreen();
 
         // If the dashboard widgets are disabled, remove them from the screens
         if (Option::get('disable_dashboard') && in_array('dashboard', $screens)) {
@@ -252,7 +257,7 @@ abstract class BaseMetabox
         }
 
         // Return early if the user doesn't have the capability to view the stats
-        if ($userCapability && !current_user_can($userCapability)) {
+        if (!User::Access('read')) {
             return;
         }
 

--- a/src/Service/Admin/LicenseManagement/Plugin/PluginActions.php
+++ b/src/Service/Admin/LicenseManagement/Plugin/PluginActions.php
@@ -50,6 +50,10 @@ class PluginActions
         check_ajax_referer('wp_rest', 'wps_nonce');
 
         try {
+            if (!User::Access('manage')) {
+                throw new Exception(esc_html__('Unauthorized access.', 'wp-statistics'));
+            }
+
             $licenseKey = Request::has('license_key') ? wp_unslash(Request::get('license_key')) : false;
             $addOn      = Request::get('addon_slug');
 
@@ -129,6 +133,10 @@ class PluginActions
         check_ajax_referer('wp_rest', 'wps_nonce');
 
         try {
+            if (!User::Access('manage')) {
+                throw new Exception(esc_html__('Unauthorized access.', 'wp-statistics'));
+            }
+
             $pluginSlug = Request::has('plugin_slug') ? wp_unslash(Request::get('plugin_slug')) : false;
             if (!$pluginSlug) {
                 throw new Exception(__('Plugin slug is missing.', 'wp-statistics'));

--- a/src/Service/Admin/Notification/NotificationActions.php
+++ b/src/Service/Admin/Notification/NotificationActions.php
@@ -2,6 +2,7 @@
 
 namespace WP_Statistics\Service\Admin\Notification;
 
+use WP_STATISTICS\User;
 use WP_Statistics\Utils\Request;
 use WP_Statistics\Components\Ajax;
 
@@ -17,8 +18,22 @@ class NotificationActions
      */
     public function register()
     {
-        Ajax::register('dismiss_notification', [$this, 'dismissNotification']);
-        Ajax::register('update_notifications_status', [$this, 'updateNotificationsStatus']);
+        Ajax::register('dismiss_notification', [$this, 'dismissNotification'], false);
+        Ajax::register('update_notifications_status', [$this, 'updateNotificationsStatus'], false);
+    }
+
+    /**
+     * Ensures the current user is allowed to change the notification state.
+     *
+     * @return void Sends a 403 JSON response and exits when the user has no access.
+     */
+    private function checkAccess()
+    {
+        if (!User::Access('manage')) {
+            wp_send_json_error([
+                'message' => esc_html__('Unauthorized.', 'wp-statistics')
+            ], 403);
+        }
     }
 
     /**
@@ -33,6 +48,8 @@ class NotificationActions
     public function dismissNotification()
     {
         check_ajax_referer('wp_rest', 'wps_nonce');
+
+        $this->checkAccess();
 
         $notificationId = Request::get('notification_id');
 
@@ -54,6 +71,8 @@ class NotificationActions
     public function updateNotificationsStatus()
     {
         check_ajax_referer('wp_rest', 'wps_nonce');
+
+        $this->checkAccess();
 
         $hasUpdatedNotifications = NotificationProcessor::updateNotificationsStatus();
 

--- a/wp-statistics.php
+++ b/wp-statistics.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wp-statistics.com/
  * GitHub Plugin URI: https://github.com/wp-statistics/wp-statistics
  * Description: Get website traffic insights with GDPR/CCPA compliant, privacy-friendly analytics. Includes visitor data, stunning graphs, and no data sharing.
- * Version: 14.16.9
+ * Version: 14.16.10
  * Author: VeronaLabs
  * Author URI: https://veronalabs.com/
  * Text Domain: wp-statistics
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/includes/defines.php';
 
 # Set another useful plugin define.
-define('WP_STATISTICS_VERSION', '14.16.9');
+define('WP_STATISTICS_VERSION', '14.16.10');
 
 # Load Plugin
 if (!class_exists('WP_Statistics')) {


### PR DESCRIPTION
## Summary
- align metabox AJAX responses with the existing read-access flow
- avoid preparing metabox data when the current user cannot read statistics
- keep the existing nonce check in place

## Test Plan
- php -l src/Abstracts/BaseMetabox.php
- git diff --check
