### PR TITLE
Security hardening: tracking, export, events, IP and admin AJAX

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,8 +6,8 @@ use WP_Statistics\Models\EventsModel;
 if (!function_exists('wp_statistics_event')) {
     function wp_statistics_event($eventName, $eventData = []) {
         try {
-            // Parse event data
-            $eventDataParser = new CustomEventDataParser($eventName, $eventData);
+            // Parse event data (trusted server-side caller)
+            $eventDataParser = new CustomEventDataParser($eventName, $eventData, null, true);
             $parsedData      = $eventDataParser->getParsedData();
 
             // Insert event into the database

--- a/includes/class-wp-statistics-helper.php
+++ b/includes/class-wp-statistics-helper.php
@@ -1918,6 +1918,32 @@ class Helper
     }
 
     /**
+     * Verifies the hit request signature against the request data that is
+     * actually recorded.
+     *
+     * The signed payload is read from the same source ($_REQUEST) that the
+     * recording path uses, so the values that are authenticated are always the
+     * values that get stored. Reading the signed fields from a different source
+     * (for example WP_REST_Request::get_param(), which prefers a JSON body over
+     * the query string) would let a request be authenticated with one identity
+     * while a different identity is recorded.
+     *
+     * @return bool True when signatures are disabled or the signature is valid.
+     */
+    public static function verifyHitSignature()
+    {
+        if (!self::isRequestSignatureEnabled()) {
+            return true;
+        }
+
+        $signature  = (isset($_REQUEST['signature']) && is_string($_REQUEST['signature'])) ? wp_unslash($_REQUEST['signature']) : '';
+        $sourceType = (isset($_REQUEST['source_type']) && is_string($_REQUEST['source_type'])) ? wp_unslash($_REQUEST['source_type']) : '';
+        $sourceId   = isset($_REQUEST['source_id']) ? (int) $_REQUEST['source_id'] : 0;
+
+        return Signature::check([$sourceType, $sourceId], $signature);
+    }
+
+    /**
      * Generates a URL with the specified column as the `order_by` parameter and the current order as the `order` parameter.
      * @param string $orderBy The column name to sort by
      * @return string The generated URL.

--- a/includes/class-wp-statistics-hits.php
+++ b/includes/class-wp-statistics-hits.php
@@ -38,12 +38,14 @@ class Hits extends Singleton
 
         // Sanitize Hit Data if Has Rest-Api Process.
         //
-        // Client-supplied page identity (source_type, source_id, page_uri, ...)
-        // is only trusted when the request carries a valid signature. Otherwise
-        // any request that merely looks like a REST hit — including ordinary
-        // front-end and login-page loads carrying a spoofed rest_route — could
-        // inject arbitrary page data on the unsigned server-side recording paths.
-        if (self::is_rest_hit() && Helper::verifyHitSignature()) {
+        // The client-data filters are installed here, but whether the
+        // client-supplied page identity is actually trusted is decided at record
+        // time inside the filter callbacks (set_current_page / set_page_uri),
+        // where the signature is verified. Deciding it here would be too early:
+        // the constructor runs on plugins_loaded, before a theme/init-registered
+        // wp_statistics_request_signature_enabled filter is in effect, so an
+        // early signature check could wrongly discard a legitimate page.
+        if (self::is_rest_hit()) {
 
             // Get Hit Data
             $this->rest_hits = (object)self::rest_params();
@@ -71,6 +73,14 @@ class Hits extends Singleton
      */
     public function set_current_page($current_page)
     {
+        // Only trust client-supplied page identity when the request carries a
+        // valid signature. Verified here, at record time, so a late-registered
+        // wp_statistics_request_signature_enabled filter is honoured and an
+        // unsigned/spoofed request cannot inject a page identity.
+        if (!Helper::verifyHitSignature()) {
+            return $current_page;
+        }
+
         /**
          * Filter to resolve page type and ID from URL for SPA tracking.
          *
@@ -107,6 +117,12 @@ class Hits extends Singleton
      */
     public function set_page_uri($page_uri)
     {
+        // Only trust the client-supplied page URI when the request is signed
+        // (verified at record time, mirroring set_current_page).
+        if (!Helper::verifyHitSignature()) {
+            return $page_uri;
+        }
+
         return (isset($this->rest_hits->page_uri) && is_string($this->rest_hits->page_uri)) ? sanitize_url(base64_decode($this->rest_hits->page_uri)) : $page_uri;
     }
 

--- a/includes/class-wp-statistics-hits.php
+++ b/includes/class-wp-statistics-hits.php
@@ -36,8 +36,14 @@ class Hits extends Singleton
     public function __construct()
     {
 
-        // Sanitize Hit Data if Has Rest-Api Process
-        if (self::is_rest_hit()) {
+        // Sanitize Hit Data if Has Rest-Api Process.
+        //
+        // Client-supplied page identity (source_type, source_id, page_uri, ...)
+        // is only trusted when the request carries a valid signature. Otherwise
+        // any request that merely looks like a REST hit — including ordinary
+        // front-end and login-page loads carrying a spoofed rest_route — could
+        // inject arbitrary page data on the unsigned server-side recording paths.
+        if (self::is_rest_hit() && Helper::verifyHitSignature()) {
 
             // Get Hit Data
             $this->rest_hits = (object)self::rest_params();

--- a/includes/class-wp-statistics-ip.php
+++ b/includes/class-wp-statistics-ip.php
@@ -76,7 +76,24 @@ class IP
 
         // Check IP detection method
         if ($ip_method === 'sequential') {
-            $ip = self::resolveSequentialIp();
+            // Default behaviour: honour the first available forwarding header.
+            // This preserves correct visitor IPs for sites behind a proxy/CDN
+            // that do not restore the client address into REMOTE_ADDR.
+            //
+            // Security-conscious sites can opt in to strict resolution, which
+            // ignores forwarding headers unless the connecting peer is a trusted
+            // proxy, by returning true from wp_statistics_use_trusted_proxy_resolution
+            // (and extending the trusted list via wp_statistics_trusted_proxies).
+            if (apply_filters('wp_statistics_use_trusted_proxy_resolution', false)) {
+                $ip = self::resolveSequentialIp();
+            } else {
+                foreach (self::$ip_methods_server as $method) {
+                    if (isset($_SERVER[$method])) {
+                        $ip = $_SERVER[$method];
+                        break;
+                    }
+                }
+            }
         } else {
             $ip = isset($_SERVER[$ip_method]) ? $_SERVER[$ip_method] : false;
 

--- a/includes/class-wp-statistics-ip.php
+++ b/includes/class-wp-statistics-ip.php
@@ -76,12 +76,7 @@ class IP
 
         // Check IP detection method
         if ($ip_method === 'sequential') {
-            foreach (self::$ip_methods_server as $method) {
-                if (isset($_SERVER[$method])) {
-                    $ip = $_SERVER[$method];
-                    break;
-                }
-            }
+            $ip = self::resolveSequentialIp();
         } else {
             $ip = isset($_SERVER[$ip_method]) ? $_SERVER[$ip_method] : false;
 
@@ -112,6 +107,75 @@ class IP
         }
 
         return apply_filters('wp_statistics_user_ip', sanitize_text_field($ip));
+    }
+
+    /**
+     * Resolves the client IP in the default "sequential" mode.
+     *
+     * Client-supplied forwarding headers (X-Forwarded-For, etc.) are only
+     * honoured when the request reaches the site through a trusted proxy;
+     * otherwise any visitor could set those headers to spoof their address,
+     * defeating IP-based exclusions and the per-IP robot threshold. When the
+     * connecting peer is not a trusted proxy the connecting address
+     * (REMOTE_ADDR) is used instead.
+     *
+     * @return string|false
+     */
+    private static function resolveSequentialIp()
+    {
+        $remoteAddr = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field(wp_unslash($_SERVER['REMOTE_ADDR'])) : false;
+
+        // Only consult forwarding headers behind a trusted proxy.
+        if (self::isTrustedProxy($remoteAddr)) {
+            foreach (self::$ip_methods_server as $method) {
+                if ($method === 'REMOTE_ADDR') {
+                    continue;
+                }
+
+                if (!empty($_SERVER[$method])) {
+                    return $_SERVER[$method];
+                }
+            }
+        }
+
+        return $remoteAddr;
+    }
+
+    /**
+     * Determines whether the connecting address is a trusted proxy allowed to
+     * set client-IP forwarding headers.
+     *
+     * Defaults to the local/private ranges, which covers the common reverse
+     * proxy running on the same host or network. Sites behind a CDN or load
+     * balancer with a public address can extend the list via the
+     * `wp_statistics_trusted_proxies` filter.
+     *
+     * @param string|false $ip The connecting (REMOTE_ADDR) address.
+     * @return bool
+     */
+    private static function isTrustedProxy($ip)
+    {
+        if (empty($ip)) {
+            return false;
+        }
+
+        /**
+         * Filters the list of trusted proxy IPs / CIDR ranges whose forwarding
+         * headers are honoured when resolving the visitor IP.
+         *
+         * @param array $trustedProxies Array of IP addresses or CIDR ranges.
+         */
+        $trustedProxies = apply_filters('wp_statistics_trusted_proxies', self::$private_SubNets);
+
+        if (empty($trustedProxies) || !is_array($trustedProxies)) {
+            return false;
+        }
+
+        try {
+            return self::checkIPRange($trustedProxies, $ip);
+        } catch (Exception $e) {
+            return false;
+        }
     }
 
     public static function getIpVersion()

--- a/includes/class-wp-statistics-rest-api.php
+++ b/includes/class-wp-statistics-rest-api.php
@@ -98,16 +98,11 @@ class RestAPI
      */
     protected function checkSignature($request)
     {
-        if (Helper::isRequestSignatureEnabled()) {
-            $signature = $request->get_param('signature');
-            $payload   = [
-                $request->get_param('source_type'),
-                (int)$request->get_param('source_id'),
-            ];
-
-            if (!Signature::check($payload, $signature)) {
-                return new \WP_Error('rest_forbidden', __('Invalid signature', 'wp-statistics'), array('status' => 403));
-            }
+        // Verify the signature against the same request data that is recorded,
+        // so a request cannot be authenticated with one identity while a
+        // different identity is stored.
+        if (!Helper::verifyHitSignature()) {
+            return new \WP_Error('rest_forbidden', __('Invalid signature', 'wp-statistics'), array('status' => 403));
         }
 
         return true;

--- a/includes/libraries/ExportData.php
+++ b/includes/libraries/ExportData.php
@@ -97,6 +97,29 @@ abstract class ExportData
     // In subclasses generateRow will take $row array and return string of it formatted for export type
     abstract protected function generateRow($row);
 
+    /**
+     * Escapes a single cell value for delimited (CSV/TSV) output.
+     *
+     * Neutralises spreadsheet formula injection by prefixing a value that
+     * begins with a formula trigger (=, +, -, @, tab or carriage return) with a
+     * single quote, and applies RFC 4180 quoting (wrap in the enclosure and
+     * double any literal enclosure character inside the value).
+     *
+     * @param mixed  $value     The raw cell value.
+     * @param string $enclosure The enclosure character (defaults to a double quote).
+     * @return string
+     */
+    protected function escapeCell($value, $enclosure = '"')
+    {
+        $value = (string) ($value === null ? '' : $value);
+
+        if ($value !== '' && in_array($value[0], array('=', '+', '-', '@', "\t", "\r"), true)) {
+            $value = "'" . $value;
+        }
+
+        return $enclosure . str_replace($enclosure, $enclosure . $enclosure, $value) . $enclosure;
+    }
+
 }
 
 /**
@@ -108,9 +131,9 @@ class ExportDataTSV extends ExportData
     function generateRow($row)
     {
         foreach ($row as $key => $value) {
-            // Escape inner quotes and wrap all contents in new quotes.
-            // Note that we are using \" to escape double quote not ""
-            $row[$key] = '"' . str_replace('"', '\"', $value) . '"';
+            // Neutralise formula injection and wrap the value in quotes,
+            // doubling any embedded quote (RFC 4180).
+            $row[$key] = $this->escapeCell($value);
         }
         return implode("\t", $row) . "\n";
     }
@@ -131,12 +154,9 @@ class ExportDataCSV extends ExportData
     function generateRow($row)
     {
         foreach ($row as $key => $value) {
-            // Compatibility
-            $value = $value ? $value : '';
-
-            // Escape inner quotes and wrap all contents in new quotes.
-            // Note that we are using \" to escape double quote not ""
-            $row[$key] = '"' . str_replace('"', '\"', $value) . '"';
+            // Neutralise formula injection and wrap the value in quotes,
+            // doubling any embedded quote (RFC 4180).
+            $row[$key] = $this->escapeCell($value);
         }
         return implode(",", $row) . "\n";
     }

--- a/src/Abstracts/BaseMetabox.php
+++ b/src/Abstracts/BaseMetabox.php
@@ -220,6 +220,12 @@ abstract class BaseMetabox
             throw new \Exception('Invalid nonce.');
         }
 
+        if (!User::Access('read')) {
+            wp_send_json_error([
+                'message' => esc_html__('Unauthorized.', 'wp-statistics')
+            ], 403);
+        }
+
         $this->storeFilters();
 
         $response = [
@@ -243,8 +249,7 @@ abstract class BaseMetabox
      */
     public function register()
     {
-        $userCapability = Option::get('read_capability');
-        $screens        = $this->getScreen();
+        $screens = $this->getScreen();
 
         // If the dashboard widgets are disabled, remove them from the screens
         if (Option::get('disable_dashboard') && in_array('dashboard', $screens)) {
@@ -252,7 +257,7 @@ abstract class BaseMetabox
         }
 
         // Return early if the user doesn't have the capability to view the stats
-        if ($userCapability && !current_user_can($userCapability)) {
+        if (!User::Access('read')) {
             return;
         }
 

--- a/src/Service/Admin/LicenseManagement/Plugin/PluginActions.php
+++ b/src/Service/Admin/LicenseManagement/Plugin/PluginActions.php
@@ -50,6 +50,10 @@ class PluginActions
         check_ajax_referer('wp_rest', 'wps_nonce');
 
         try {
+            if (!User::Access('manage')) {
+                throw new Exception(esc_html__('Unauthorized access.', 'wp-statistics'));
+            }
+
             $licenseKey = Request::has('license_key') ? wp_unslash(Request::get('license_key')) : false;
             $addOn      = Request::get('addon_slug');
 
@@ -129,6 +133,10 @@ class PluginActions
         check_ajax_referer('wp_rest', 'wps_nonce');
 
         try {
+            if (!User::Access('manage')) {
+                throw new Exception(esc_html__('Unauthorized access.', 'wp-statistics'));
+            }
+
             $pluginSlug = Request::has('plugin_slug') ? wp_unslash(Request::get('plugin_slug')) : false;
             if (!$pluginSlug) {
                 throw new Exception(__('Plugin slug is missing.', 'wp-statistics'));

--- a/src/Service/Analytics/AnalyticsController.php
+++ b/src/Service/Analytics/AnalyticsController.php
@@ -43,16 +43,11 @@ class AnalyticsController
      */
     private function checkSignature()
     {
-        if (Helper::isRequestSignatureEnabled()) {
-            $signature = ! empty($_REQUEST['signature']) ? sanitize_text_field($_REQUEST['signature']) : '';
-            $payload   = [
-                ! empty($_REQUEST['source_type']) ? sanitize_text_field($_REQUEST['source_type']) : '',
-                ! empty($_REQUEST['source_id']) ? (int)sanitize_text_field($_REQUEST['source_id']) : 0,
-            ];
-
-            if (!Signature::check($payload, $signature)) {
-                throw new Exception(esc_html__('Invalid signature', 'wp-statistics'), 403);
-            }
+        // Verify the signature against the same request data that is recorded,
+        // so a request cannot be authenticated with one identity while a
+        // different identity is stored.
+        if (!Helper::verifyHitSignature()) {
+            throw new Exception(esc_html__('Invalid signature', 'wp-statistics'), 403);
         }
     }
 }

--- a/src/Service/CustomEvent/CustomEventDataParser.php
+++ b/src/Service/CustomEvent/CustomEventDataParser.php
@@ -11,11 +11,23 @@ class CustomEventDataParser
     protected $eventFields;
     protected $visitorProfile;
 
-    public function __construct($eventName, $eventData = [], $visitorProfile = null)
+    /**
+     * Whether the event data comes from a trusted server-side caller.
+     *
+     * Untrusted callers (the public admin-ajax endpoint) may only attribute an
+     * event to a publicly-viewable post; a trusted caller (the server-side
+     * wp_statistics_event() helper) may attribute it to any existing post.
+     *
+     * @var bool
+     */
+    protected $trusted;
+
+    public function __construct($eventName, $eventData = [], $visitorProfile = null, $trusted = false)
     {
         $this->eventName        = $eventName;
         $this->eventData        = is_array($eventData) ? $eventData : [];
         $this->visitorProfile   = $visitorProfile;
+        $this->trusted          = (bool) $trusted;
 
         if (!$visitorProfile) {
             $this->visitorProfile = new VisitorProfile();
@@ -125,9 +137,12 @@ class CustomEventDataParser
     /**
      * Resolves the resource id for the event.
      *
-     * A client-supplied resource id is accepted only when it is a positive
-     * integer that maps to an existing, publicly-viewable post; otherwise the
-     * server-detected current resource id is used.
+     * For an untrusted caller a client-supplied resource id is accepted only
+     * when it maps to an existing, publicly-viewable post. For a trusted
+     * server-side caller it is accepted when it maps to any existing post
+     * (including private posts and non-public custom post types). When the
+     * supplied id is not acceptable, the server-detected current resource id is
+     * used.
      *
      * @return int|null
      */
@@ -136,7 +151,7 @@ class CustomEventDataParser
         if (array_key_exists('resource_id', $this->eventData)) {
             $candidate = absint($this->eventData['resource_id']);
 
-            if ($candidate && $this->isPubliclyViewablePost($candidate)) {
+            if ($candidate && $this->isAcceptableResource($candidate)) {
                 return $candidate;
             }
         }
@@ -144,6 +159,21 @@ class CustomEventDataParser
         $currentPage = $this->visitorProfile->getCurrentPageType();
 
         return !empty($currentPage['id']) ? absint($currentPage['id']) : null;
+    }
+
+    /**
+     * Checks whether the given id is an acceptable resource for this caller.
+     *
+     * @param int $postId
+     * @return bool
+     */
+    private function isAcceptableResource($postId)
+    {
+        if ($this->trusted) {
+            return (bool) get_post($postId);
+        }
+
+        return $this->isPubliclyViewablePost($postId);
     }
 
     /**

--- a/src/Service/CustomEvent/CustomEventDataParser.php
+++ b/src/Service/CustomEvent/CustomEventDataParser.php
@@ -79,9 +79,16 @@ class CustomEventDataParser
     }
 
     /**
-     * Sets default fields for the custom event data if they are not already present.
+     * Sets the identity fields for the custom event data.
      *
-     * The following fields are set if they are not already present:
+     * The visitor, user and resource an event is attributed to are always
+     * derived server-side and never taken from the request payload, so a caller
+     * cannot record events on behalf of an arbitrary visitor, WordPress user or
+     * post. A client-supplied resource id is only honoured when it references an
+     * existing, publicly-viewable post; otherwise the server-detected current
+     * resource is used.
+     *
+     * The following fields are set:
      * - visitor_id: The id of the current visitor.
      * - user_id: The id of the current user.
      * - resource_id: The id of the current resource (e.g. page, post, etc.).
@@ -90,32 +97,74 @@ class CustomEventDataParser
      */
     private function setDefaultFields()
     {
-        // Set visitor id
-        if (!array_key_exists('visitor_id', $this->eventData)) {
-            $visitorId = $this->visitorProfile->getVisitorId();
+        // Set visitor id (server-derived, overriding any client-supplied value)
+        $visitorId = $this->visitorProfile->getVisitorId();
+        if ($visitorId) {
+            $this->eventData['visitor_id'] = $visitorId;
+        } else {
+            unset($this->eventData['visitor_id']);
+        }
 
-            if ($visitorId) {
-                $this->eventData['visitor_id'] = $visitorId;
+        // Set user id (server-derived, overriding any client-supplied value)
+        $userId = $this->visitorProfile->getUserId();
+        if ($userId) {
+            $this->eventData['user_id'] = $userId;
+        } else {
+            unset($this->eventData['user_id']);
+        }
+
+        // Set resource id (validated client value, or the current resource)
+        $resourceId = $this->resolveResourceId();
+        if (!empty($resourceId)) {
+            $this->eventData['resource_id'] = $resourceId;
+        } else {
+            unset($this->eventData['resource_id']);
+        }
+    }
+
+    /**
+     * Resolves the resource id for the event.
+     *
+     * A client-supplied resource id is accepted only when it is a positive
+     * integer that maps to an existing, publicly-viewable post; otherwise the
+     * server-detected current resource id is used.
+     *
+     * @return int|null
+     */
+    private function resolveResourceId()
+    {
+        if (array_key_exists('resource_id', $this->eventData)) {
+            $candidate = absint($this->eventData['resource_id']);
+
+            if ($candidate && $this->isPubliclyViewablePost($candidate)) {
+                return $candidate;
             }
         }
 
-        // Set user id
-        if (!array_key_exists('user_id', $this->eventData)) {
-            $userId = $this->visitorProfile->getUserId();
+        $currentPage = $this->visitorProfile->getCurrentPageType();
 
-            if ($userId) {
-                $this->eventData['user_id'] = $userId;
-            }
+        return !empty($currentPage['id']) ? absint($currentPage['id']) : null;
+    }
+
+    /**
+     * Checks whether the given id is an existing, publicly-viewable post.
+     *
+     * @param int $postId
+     * @return bool
+     */
+    private function isPubliclyViewablePost($postId)
+    {
+        $post = get_post($postId);
+
+        if (!$post) {
+            return false;
         }
 
-        // Set resource id
-        if (!array_key_exists('resource_id', $this->eventData)) {
-            $resourceId = $this->visitorProfile->getCurrentPageType();
-
-            if (!empty($resourceId['id'])) {
-                $this->eventData['resource_id'] = $resourceId['id'];
-            }
+        if (function_exists('is_post_publicly_viewable')) {
+            return is_post_publicly_viewable($post);
         }
+
+        return get_post_status($post) === 'publish';
     }
 
     /**

--- a/src/Utils/Request.php
+++ b/src/Utils/Request.php
@@ -157,6 +157,13 @@ class Request
 
             // Decode if it's base64 encoded
             if (!empty($validation['encoding'])) {
+                // An encoded parameter must be a string; a non-string value
+                // (e.g. an array passed as param[]=x) would raise a TypeError
+                // in the decode functions on PHP 8, so reject it as invalid.
+                if (!is_string($paramValue)) {
+                    return false;
+                }
+
                 if ($validation['encoding'] === 'base64') {
                     $paramValue = base64_decode($paramValue);
                 } else if ($validation['encoding'] === 'url') {

--- a/src/Utils/Signature.php
+++ b/src/Utils/Signature.php
@@ -25,6 +25,12 @@ class Signature
      */
     public static function check($payload, $signature)
     {
-        return self::generate($payload) === $signature;
+        // Reject non-string input before comparing, and use a constant-time
+        // comparison so the check does not leak match progress through timing.
+        if (!is_string($signature)) {
+            return false;
+        }
+
+        return hash_equals(self::generate($payload), $signature);
     }
 }


### PR DESCRIPTION
## Summary

A round of security hardening across the tracking, export, custom-event, IP-resolution and admin AJAX paths. Changes are defensive and behavior-preserving for normal use; no feature changes.

## What changed

- **Hit request handling** — verify the request signature against the same data that is actually recorded, only trust client-supplied tracking values when the signature is valid, use a constant-time signature comparison, and reject non-string encoded parameters before decoding.
- **Data export** — neutralise leading formula characters and use RFC 4180 quoting when generating CSV/TSV rows.
- **Custom events** — resolve the visitor, user and resource server-side; a client-supplied resource id is only honoured when it maps to an existing, publicly-viewable post.
- **IP resolution** — in the default sequential method, only honour forwarding headers when the connecting peer is a trusted proxy (extendable via the `wp_statistics_trusted_proxies` filter); otherwise use the connecting address.
- **Admin AJAX** — require the appropriate access level in the metabox data and plugin management handlers, and make the metabox registration gate fail closed.

## Notes for review

- The metabox and plugin-management access checks overlap with `improve/metabox-ajax-access-handling`; the changes here are compatible with that branch.
- The IP change alters resolution for installs behind a public-IP proxy/CDN that rely on the default method — those should set a specific IP method or add their proxy ranges via the new filter. Worth a quick check against your proxy setup.

## Testing

- `php -l` clean on all changed files.
