### PR TITLE
Reschedule email reports when frequency changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 14.16.11 - Unreleased
+- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
-- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 14.16.9 - 2026-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
+- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 14.16.9 - 2026-07-21

--- a/includes/class-wp-statistics-schedule.php
+++ b/includes/class-wp-statistics-schedule.php
@@ -58,20 +58,23 @@ class Schedule
             wp_schedule_event(time(), 'monthly', 'wp_statistics_referrals_db_hook');
         }
 
+        $timeReports          = Option::get('time_report');
+        $scheduledReportEvent = wp_get_scheduled_event('wp_statistics_report_hook');
+
+        // Remove the report schedule if its frequency has changed or reports are disabled.
+        if ($scheduledReportEvent && $scheduledReportEvent->schedule !== $timeReports) {
+            wp_unschedule_event($scheduledReportEvent->timestamp, 'wp_statistics_report_hook');
+            $scheduledReportEvent = false;
+        }
+
         // Add the report schedule if it doesn't exist and is enabled.
-        if (!wp_next_scheduled('wp_statistics_report_hook') && Option::get('time_report') != '0') {
-            $timeReports       = Option::get('time_report');
+        if (!$scheduledReportEvent && $timeReports != '0') {
             $schedulesInterval = self::getSchedules();
 
             if (isset($schedulesInterval[$timeReports], $schedulesInterval[$timeReports]['next_schedule'])) {
                 $scheduleTime = $schedulesInterval[$timeReports]['next_schedule'];
                 wp_schedule_event($scheduleTime, $timeReports, 'wp_statistics_report_hook');
             }
-        }
-
-        // Remove the report schedule if it does exist and is disabled.
-        if (wp_next_scheduled('wp_statistics_report_hook') && Option::get('time_report') == '0') {
-            wp_unschedule_event(wp_next_scheduled('wp_statistics_report_hook'), 'wp_statistics_report_hook');
         }
 
         // Schedule license migration

--- a/includes/class-wp-statistics-schedule.php
+++ b/includes/class-wp-statistics-schedule.php
@@ -63,8 +63,9 @@ class Schedule
 
         // Remove the report schedule if its frequency has changed or reports are disabled.
         if ($scheduledReportEvent && $scheduledReportEvent->schedule !== $timeReports) {
-            wp_unschedule_event($scheduledReportEvent->timestamp, 'wp_statistics_report_hook');
-            $scheduledReportEvent = false;
+            if (wp_unschedule_event($scheduledReportEvent->timestamp, 'wp_statistics_report_hook')) {
+                $scheduledReportEvent = false;
+            }
         }
 
         // Add the report schedule if it doesn't exist and is enabled.
@@ -73,7 +74,10 @@ class Schedule
 
             if (isset($schedulesInterval[$timeReports], $schedulesInterval[$timeReports]['next_schedule'])) {
                 $scheduleTime = $schedulesInterval[$timeReports]['next_schedule'];
-                wp_schedule_event($scheduleTime, $timeReports, 'wp_statistics_report_hook');
+
+                if (wp_schedule_event($scheduleTime, $timeReports, 'wp_statistics_report_hook')) {
+                    $scheduledReportEvent = true;
+                }
             }
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -146,9 +146,11 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.11 - Unreleased =
+- **Fix:** Email report schedules now update when the configured report frequency changes.
+
 = 14.16.10 - 2026-07-25 =
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
-- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 = 14.16.9 - 2026-07-21 =

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,7 @@ Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest versio
 == Changelog ==
 = 14.16.10 - 2026-07-25 =
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
+- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 = 14.16.9 - 2026-07-21 =

--- a/tests/unit/Test_Schedule.php
+++ b/tests/unit/Test_Schedule.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WP_Statistics\Tests;
+
+use WP_STATISTICS\Option;
+use WP_STATISTICS\Schedule;
+use WP_UnitTestCase;
+
+class Test_Schedule extends WP_UnitTestCase
+{
+    private const REPORT_HOOK = 'wp_statistics_report_hook';
+
+    public function tearDown(): void
+    {
+        wp_clear_scheduled_hook(self::REPORT_HOOK);
+        Option::update('time_report', '0');
+
+        parent::tearDown();
+    }
+
+    public function test_report_event_is_rescheduled_when_frequency_changes()
+    {
+        Option::update('time_report', 'weekly');
+        wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::REPORT_HOOK);
+
+        Schedule::get_instance()->maybe_schedule_hooks();
+
+        $this->assertSame('weekly', wp_get_schedule(self::REPORT_HOOK));
+    }
+}

--- a/tests/unit/Test_Schedule.php
+++ b/tests/unit/Test_Schedule.php
@@ -10,10 +10,31 @@ class Test_Schedule extends WP_UnitTestCase
 {
     private const REPORT_HOOK = 'wp_statistics_report_hook';
 
+    private const SCHEDULE_HOOKS = [
+        'wp_statistics_dbmaint_hook',
+        'wp_statistics_referrals_db_hook',
+        self::REPORT_HOOK,
+        'wp_statistics_licenses_hook',
+        'wp_statistics_geoip_hook',
+        'wp_statistics_check_licenses_status',
+    ];
+
+    private $originalTimeReport;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalTimeReport = Option::get('time_report');
+    }
+
     public function tearDown(): void
     {
-        wp_clear_scheduled_hook(self::REPORT_HOOK);
-        Option::update('time_report', '0');
+        foreach (self::SCHEDULE_HOOKS as $hook) {
+            wp_clear_scheduled_hook($hook);
+        }
+
+        Option::update('time_report', $this->originalTimeReport);
 
         parent::tearDown();
     }

--- a/tests/unit/Test_Schedule.php
+++ b/tests/unit/Test_Schedule.php
@@ -42,7 +42,10 @@ class Test_Schedule extends WP_UnitTestCase
     public function test_report_event_is_rescheduled_when_frequency_changes()
     {
         Option::update('time_report', 'weekly');
-        wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::REPORT_HOOK);
+        wp_clear_scheduled_hook(self::REPORT_HOOK);
+
+        $this->assertTrue(wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::REPORT_HOOK));
+        $this->assertSame('daily', wp_get_schedule(self::REPORT_HOOK));
 
         Schedule::get_instance()->maybe_schedule_hooks();
 


### PR DESCRIPTION
## What changed
- Compare the existing report cron recurrence with the configured report frequency during schedule initialization.
- Unschedule an outdated report event before scheduling the newly selected recurrence.
- Add a regression test covering a daily-to-weekly frequency change.

## Why
Changing Report Frequency updated the option but could leave the existing cron event on its old recurrence. The scheduler now reconciles the cron event with the saved setting.

## How to test
- `WP_TESTS_PHPUNIT_POLYFILLS_PATH=/root/.composer/vendor/yoast/phpunit-polyfills /root/.composer/vendor/bin/phpunit --filter test_report_event_is_rescheduled_when_frequency_changes tests/unit/Test_Schedule.php --testdox`

Closes #1108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email report schedules now update correctly when the configured reporting frequency changes.
  * Existing report events are replaced with the newly selected schedule.
  * Scheduled reports are removed when reporting is disabled.

* **Tests**
  * Added coverage for changing report frequencies and scheduled report cleanup.
  * Improved test isolation for scheduled report settings.

* **Documentation**
  * Updated release documentation to note the report scheduling improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->