### PR TITLE
Avoid admin work for users without statistics access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 14.16.11 - Unreleased
 - **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
+- **Enhancement:** Reduced admin dashboard work by skipping statistics metabox discovery and assets for users without statistics access.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -508,7 +508,7 @@ class Admin_Assets
         // For developers: WordPress debugging mode.
         $list['wp_debug'] = defined('WP_DEBUG') && WP_DEBUG ? true : false;
 
-        $list['meta_boxes'] = MetaboxHelper::getScreenMetaboxes();
+        $list['meta_boxes'] = User::Access('read') ? MetaboxHelper::getScreenMetaboxes() : [];
 
         $list['wps_page'] = Context::get('wps_page');
 

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -144,6 +144,9 @@ class Admin_Assets
      */
     public function admin_styles()
     {
+        if (!User::Access()) {
+            return;
+        }
 
         // Get Current Screen ID
         $screen_id = Helper::get_screen_id();
@@ -185,6 +188,9 @@ class Admin_Assets
      */
     public function admin_scripts($hook)
     {
+        if (!User::Access()) {
+            return;
+        }
 
         // Get Current Screen ID
         $screen_id = Helper::get_screen_id();

--- a/src/Service/Admin/Metabox/MetaboxManager.php
+++ b/src/Service/Admin/Metabox/MetaboxManager.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use WP_Screen;
 use WP_Statistics\Core\CoreFactory;
+use WP_STATISTICS\User;
 
 class MetaboxManager
 {
@@ -22,6 +23,10 @@ class MetaboxManager
      */
     public function registerMetaboxes()
     {
+        if (!User::Access('read')) {
+            return;
+        }
+
         $metaboxes = MetaboxHelper::getActiveMetaboxes();
 
         foreach ($metaboxes as $metabox) {
@@ -39,6 +44,10 @@ class MetaboxManager
      */
     public function hideDashboardMetaboxes()
     {
+        if (!User::Access('read')) {
+            return;
+        }
+
         $userId             = get_current_user_id();
         $hiddenMetaboxesKey = 'metaboxhidden_dashboard';
         $metaboxInitFlagKey = 'wp_statistics_metaboxhidden_dashboard_initialized';

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -47,6 +47,7 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
         }
 
         remove_role('wps_manager_only');
+        remove_role('wps_reader_only');
         wp_set_current_user(0);
         set_current_screen('front');
 
@@ -93,7 +94,24 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
     public function test_authorized_readers_receive_admin_assets()
     {
-        $this->setCurrentUserWithRole('administrator');
+        add_role(
+            'wps_reader_only',
+            'WP Statistics Reader',
+            [
+                'read'           => true,
+                'wps_read_stats' => true,
+            ]
+        );
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        $this->setCurrentUserWithRole('wps_reader_only');
+
+        $this->assertTrue(User::Access('read'));
+        $this->assertFalse(User::Access('manage'));
 
         $this->assets->admin_styles();
         $this->assets->admin_scripts('index.php');

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -131,6 +131,7 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
         $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertSame(0, $this->metaboxListCalls);
     }
 
     private function setCurrentUserWithRole(string $role): void

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -1,0 +1,147 @@
+<?php
+
+use WP_Statistics\Service\Admin\Metabox\MetaboxManager;
+use WP_STATISTICS\Admin_Assets;
+use WP_STATISTICS\Option;
+use WP_STATISTICS\User;
+
+class Test_AdminAccessGuards extends WP_UnitTestCase
+{
+    private $assets;
+    private $metaboxManager;
+    private $metaboxListCalls = 0;
+    private $originalOptions;
+    private $hadOriginalOptions;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists(Admin_Assets::class)) {
+            require_once WP_STATISTICS_DIR . 'includes/admin/class-wp-statistics-admin-assets.php';
+        }
+
+        $this->originalOptions    = get_option(Option::$opt_name);
+        $this->hadOriginalOptions = false !== $this->originalOptions;
+        $this->assets             = new Admin_Assets();
+        $this->metaboxManager     = new MetaboxManager();
+
+        add_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
+        set_current_screen('dashboard');
+        $this->resetAssetQueues();
+    }
+
+    public function tearDown(): void
+    {
+        remove_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
+        remove_action('admin_init', [$this->metaboxManager, 'registerMetaboxes']);
+        remove_action('admin_init', [$this->metaboxManager, 'hideDashboardMetaboxes']);
+        remove_action('admin_enqueue_scripts', [$this->assets, 'admin_styles'], 999);
+        remove_action('admin_enqueue_scripts', [$this->assets, 'admin_scripts'], 999);
+        remove_filter('wp_statistics_enqueue_chartjs', [$this->assets, 'shouldEnqueueChartJs']);
+
+        if ($this->hadOriginalOptions) {
+            update_option(Option::$opt_name, $this->originalOptions);
+        } else {
+            delete_option(Option::$opt_name);
+        }
+
+        remove_role('wps_manager_only');
+        wp_set_current_user(0);
+        set_current_screen('front');
+
+        parent::tearDown();
+    }
+
+    public function recordMetaboxList(array $metaboxes): array
+    {
+        $this->metaboxListCalls++;
+
+        return [];
+    }
+
+    public function test_unauthorized_users_do_not_build_metaboxes()
+    {
+        $this->setCurrentUserWithRole('subscriber');
+
+        $this->metaboxManager->registerMetaboxes();
+        $this->metaboxManager->hideDashboardMetaboxes();
+
+        $this->assertSame(0, $this->metaboxListCalls);
+    }
+
+    public function test_authorized_readers_build_metaboxes()
+    {
+        $this->setCurrentUserWithRole('administrator');
+
+        $this->metaboxManager->registerMetaboxes();
+        $this->metaboxManager->hideDashboardMetaboxes();
+
+        $this->assertSame(2, $this->metaboxListCalls);
+    }
+
+    public function test_unauthorized_users_do_not_receive_admin_assets()
+    {
+        $this->setCurrentUserWithRole('subscriber');
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertFalse(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertFalse(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    public function test_authorized_readers_receive_admin_assets()
+    {
+        $this->setCurrentUserWithRole('administrator');
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    public function test_manage_only_users_keep_admin_assets_but_skip_metaboxes()
+    {
+        add_role(
+            'wps_manager_only',
+            'WP Statistics Manager',
+            [
+                'read'             => true,
+                'wps_manage_stats' => true,
+            ]
+        );
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        $this->setCurrentUserWithRole('wps_manager_only');
+
+        $this->assertTrue(User::Access('manage'));
+        $this->assertFalse(User::Access('read'));
+
+        $this->metaboxManager->registerMetaboxes();
+        $this->assertSame(0, $this->metaboxListCalls);
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    private function setCurrentUserWithRole(string $role): void
+    {
+        $userId = self::factory()->user->create(['role' => $role]);
+        wp_set_current_user($userId);
+    }
+
+    private function resetAssetQueues(): void
+    {
+        wp_styles()->queue  = [];
+        wp_scripts()->queue = [];
+    }
+}


### PR DESCRIPTION
## Summary

- stop dashboard metabox discovery before constructing data providers when the current user lacks statistics read access
- skip WP Statistics admin styles and scripts when the current user has neither read nor manage access
- preserve assets for read-capable users and manage-only configurations

## Why

Unauthorized dashboard users did not see WP Statistics UI, but the plugin still constructed every active metabox and enqueued its complete dashboard asset bundle. The access checks now happen before that work.

## Verification

- `phpunit --filter Test_AdminAccessGuards`: 5 tests, 11 assertions passed in single-site and multisite modes
- full PHPUnit suite: 117 tests, 234 assertions passed
- PHP syntax checks passed for all changed files
- live multisite subscriber request: HTTP 200, no WP Statistics assets or toolbar, object-cache reads reduced from 5,090 to 4,186 in the controlled profile
- live authorized site-administrator request: HTTP 200 with WP Statistics assets, toolbar, and dashboard widgets preserved

The local test database emits pre-existing setup warnings because the statistics tables are not installed, but all targeted and full suites complete successfully.

Fixes #1110


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted admin styles and scripts to users with appropriate access.
  * Prevented unauthorized users from viewing or creating admin metaboxes.
  * Preserved asset access for users with management permissions, while limiting metaboxes to users with read access.

* **Tests**
  * Added coverage verifying access behavior for administrators, authorized readers, and unauthorized users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->