### PR TITLE
Confirm WordPress 7.1 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
 - **Enhancement:** Reduced admin dashboard work by skipping statistics metabox discovery and assets for users without statistics access.
+- **Enhancement:** Tested up to WordPress v7.1.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: veronalabs, mostafa.s1990, kashani, GregRoss
 Donate link: https://wp-statistics.com/donate/
 Tags: analytics, google analytics, insights, stats, site visitors
 Requires at least: 6.6
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 14.16.10
 Requires PHP: 7.4
 License: GPL-2.0+


### PR DESCRIPTION
## What changed
- Updated the WordPress.org `Tested up to` metadata from 7.0 to 7.1.
- Added a WordPress 7.1 compatibility note to the 14.16.11 Unreleased changelog.

## Why
WP Statistics 14.16.10 activates and its primary admin/frontend paths run successfully on WordPress 7.1 RC3, so the release metadata can advertise 7.1 compatibility. No compatibility code changes were required.

## QA / how to test
Tested with **WordPress 7.1 RC3**, PHP 8.4.23, and MariaDB 11.8.6:
- Installed WordPress and activated WP Statistics 14.16.10 successfully.
- Confirmed all 8 plugin database tables were created.
- Created and rendered a published post on the frontend (HTTP 200).
- Logged in and rendered both the WordPress dashboard and WP Statistics overview screen (HTTP 200).
- Enabled `WP_DEBUG`/`WP_DEBUG_LOG`; no PHP warnings, fatal errors, or deprecation notices were logged during these flows.
- Focused PHPUnit check: `WP_CORE_DIR=/tmp/wp-statistics-1112-wp71 WP_TESTS_DIR=/tmp/wp-statistics-1112-tests WP_TESTS_PHPUNIT_POLYFILLS_PATH=/root/.composer/vendor/yoast/phpunit-polyfills /root/.composer/vendor/bin/phpunit --testdox tests/unit/Test_Url.php` — **4 tests, 15 assertions passed**.
- Metadata/changelog check and `git diff --check` passed.

Closes #1112
