### PR TITLE
Improve GeoIP update failure diagnostics

### DIFF
--- a/includes/admin/templates/settings/advanced.php
+++ b/includes/admin/templates/settings/advanced.php
@@ -383,10 +383,17 @@ add_thickbox();
                         geoipClickedButton.classList.remove('wps-loading-button');
                         var alertClass = result.success ? 'wps-alert__success' : 'wps-alert__danger';
                         var message = result.data && result.data.message ? result.data.message : '';
-                        jQuery(geoipClickedButton).after("<div class='wps-alert wps-alert-box " + alertClass + "'><span>" + message + "</span></div>");
-                    }).fail(function () {
+                        var alert = jQuery("<div class='wps-alert wps-alert-box " + alertClass + "'><span></span></div>");
+                        alert.find('span').text(message);
+                        jQuery(geoipClickedButton).after(alert);
+                    }).fail(function (xhr) {
                         geoipClickedButton.classList.remove('wps-loading-button');
-                        jQuery(geoipClickedButton).after("<div class='wps-alert wps-alert-box wps-alert__danger'><span><?php esc_html_e('Oops! Something went wrong. Please try again. For more details, check the PHP Error Log.', 'wp-statistics'); ?></span></div>");
+                        var message = xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message
+                            ? xhr.responseJSON.data.message
+                            : '<?php echo esc_js(__('Oops! Something went wrong. Please try again. For more details, check the PHP Error Log.', 'wp-statistics')); ?>';
+                        var alert = jQuery("<div class='wps-alert wps-alert-box wps-alert__danger'><span></span></div>");
+                        alert.find('span').text(message);
+                        jQuery(geoipClickedButton).after(alert);
                     });
                 });
             });

--- a/includes/class-wp-statistics-geoip.php
+++ b/includes/class-wp-statistics-geoip.php
@@ -42,7 +42,7 @@ class GeoIP
     /**
      * Downloads the GeoIP database from MaxMind.
      *
-     * @return mixed Array containing status and notice messages.
+     * @return bool|\WP_Error True on success, or WP_Error on failure.
      * @deprecated This method is deprecated and should not be used in new development. use GeolocationFactory::downloadDatabase() instead.
      */
     public static function download()

--- a/src/Service/Admin/SiteHealthInfo.php
+++ b/src/Service/Admin/SiteHealthInfo.php
@@ -145,7 +145,7 @@ class SiteHealthInfo
             'geoIpDatabaseValidation'        => [
                 'label' => esc_html__('GeoIP Database Validation', 'wp-statistics'),
                 'value' => is_wp_error($geoIpProviderValidity) ? esc_html__('No', 'wp-statistics') : esc_html__('Yes', 'wp-statistics'),
-                'debug' => is_wp_error($geoIpProviderValidity) ? $geoIpProviderValidity->get_error_code() : 'Yes',
+                'debug' => is_wp_error($geoIpProviderValidity) ? $geoIpProviderValidity->get_error_message() : 'Yes',
             ],
 
             /**

--- a/src/Service/Geolocation/GeoServiceProviderInterface.php
+++ b/src/Service/Geolocation/GeoServiceProviderInterface.php
@@ -2,6 +2,8 @@
 
 namespace WP_Statistics\Service\Geolocation;
 
+use WP_Error;
+
 interface GeoServiceProviderInterface
 {
     /**
@@ -22,7 +24,7 @@ interface GeoServiceProviderInterface
     /**
      * Download the GeoIP database, extract it, and handle updates.
      *
-     * @return array
+     * @return bool|WP_Error True on success, or WP_Error on failure.
      */
     public function downloadDatabase();
 

--- a/src/Service/Geolocation/Provider/CloudflareGeolocationProvider.php
+++ b/src/Service/Geolocation/Provider/CloudflareGeolocationProvider.php
@@ -6,6 +6,7 @@ use WP_STATISTICS\Country;
 use WP_STATISTICS\IP;
 use WP_Statistics\Service\Geolocation\AbstractGeoIPProvider;
 use Exception;
+use WP_Error;
 
 class CloudflareGeolocationProvider extends AbstractGeoIPProvider
 {
@@ -140,9 +141,14 @@ class CloudflareGeolocationProvider extends AbstractGeoIPProvider
         return '';
     }
 
+    /**
+     * Cloudflare does not require a local database download.
+     *
+     * @return bool|WP_Error True on success, or WP_Error on failure.
+     */
     public function downloadDatabase()
     {
-        return [];
+        return true;
     }
 
     public function getDatabaseType()

--- a/src/Service/Geolocation/Provider/DbIpProvider.php
+++ b/src/Service/Geolocation/Provider/DbIpProvider.php
@@ -120,6 +120,11 @@ class DbIpProvider extends AbstractGeoIPProvider
         return $this->getFilteredDownloadUrl($defaultUrl);
     }
 
+    /**
+     * Download the GeoIP database, extract it, and handle updates.
+     *
+     * @return bool|WP_Error True on success, or WP_Error on failure.
+     */
     public function downloadDatabase()
     {
         $gzFilePath = $this->getFilePath('dbip-city-lite.mmdb.gz');

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -144,15 +144,15 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
             ]);
 
             if (is_wp_error($response)) {
-                /* translators: %1$s: string value, %2$s: string value */
-                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database from: %1$s - %2$s', 'wp-statistics'), $downloadUrl, $response->get_error_message()));
+                /* translators: %s: transport error message */
+                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database: %s', 'wp-statistics'), $response->get_error_message()));
             }
 
             // Check the HTTP status code
             $statusCode = wp_remote_retrieve_response_code($response);
             if ($statusCode !== 200) {
-                /* translators: %1$d: number value, %2$s: string value */
-                throw new Exception(sprintf(esc_html__('Unexpected HTTP status code %1$d while downloading GeoIP database from: %2$s', 'wp-statistics'), $statusCode, $downloadUrl));
+                /* translators: %d: HTTP status code */
+                throw new Exception(sprintf(esc_html__('Unexpected HTTP status code %d while downloading GeoIP database.', 'wp-statistics'), $statusCode));
             }
 
             $this->extractGzFile($gzFilePath, $tempDbFile);

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -125,19 +125,28 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
     /**
      * Download the GeoIP database, extract it, and handle updates.
      *
-     * @return array
+     * @return bool|WP_Error
      */
     public function downloadDatabase()
     {
         $gzFilePath = $this->getFilePath('GeoLite2-City.mmdb.gz');
+        $dbFile     = $this->getDatabasePath();
+        $tempDbFile = $dbFile . '.tmp';
 
         try {
+            $this->deleteFile($tempDbFile);
+
             $downloadUrl = $this->getDownloadUrl();
             $response    = wp_remote_get($downloadUrl, [
                 'stream'   => true,
                 'filename' => $gzFilePath,
                 'timeout'  => 120,
             ]);
+
+            if (is_wp_error($response)) {
+                /* translators: %1$s: string value, %2$s: string value */
+                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database from: %1$s - %2$s', 'wp-statistics'), $downloadUrl, $response->get_error_message()));
+            }
 
             // Check the HTTP status code
             $statusCode = wp_remote_retrieve_response_code($response);
@@ -146,15 +155,15 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
                 throw new Exception(sprintf(esc_html__('Unexpected HTTP status code %1$d while downloading GeoIP database from: %2$s', 'wp-statistics'), $statusCode, $downloadUrl));
             }
 
-            if (is_wp_error($response)) {
-                /* translators: %1$s: string value, %2$s: string value */
-                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database from: %1$s - %2$s', 'wp-statistics'), $downloadUrl, $response->get_error_message()));
+            $this->extractGzFile($gzFilePath, $tempDbFile);
+            $this->validateDownloadedDatabaseFile($tempDbFile);
+
+            if (!rename($tempDbFile, $dbFile)) {
+                throw new Exception(esc_html__('Failed to replace the existing GeoIP database. The existing database was left unchanged.', 'wp-statistics'));
             }
 
-            $dbFile = $this->getDatabasePath();
-
-            $this->extractGzFile($gzFilePath, $dbFile); // Extract the downloaded file
             $this->deleteFile($gzFilePath); // Clean up the temporary file
+            $this->reader = new Reader($dbFile);
 
             // Update options and send notifications
             $this->updateLastDownloadTimestamp();
@@ -169,6 +178,7 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
 
         } catch (Exception $e) {
             $this->deleteFile($gzFilePath); // Ensure temporary file is deleted in case of an error
+            $this->deleteFile($tempDbFile);
 
             WP_Statistics::log($e->getMessage()); // Log the error for debugging
 
@@ -176,6 +186,32 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
         }
 
         return true;
+    }
+
+    /**
+     * Validate a downloaded database before replacing the active database.
+     *
+     * @param string $databasePath
+     * @return void
+     * @throws Exception
+     */
+    protected function validateDownloadedDatabaseFile(string $databasePath)
+    {
+        try {
+            $reader       = new Reader($databasePath);
+            $databaseType = $reader->metadata()->databaseType;
+
+            if ($databaseType !== 'GeoLite2-City') {
+                /* translators: %s: string value */
+                throw new Exception(sprintf(esc_html__('Unexpected database type %s', 'wp-statistics'), $databaseType));
+            }
+        } catch (Exception $e) {
+            throw new Exception(sprintf(
+                /* translators: %s: validation error message */
+                esc_html__('The downloaded MaxMind GeoIP database is invalid: %s The existing database was left unchanged. Please delete the MaxMind database and retry the update, or switch to DB-IP and download its database.', 'wp-statistics'),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/tests/integration/Test_MaxmindGeoIPProvider.php
+++ b/tests/integration/Test_MaxmindGeoIPProvider.php
@@ -69,6 +69,36 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertStringContainsString('switch to DB-IP', $result->get_error_message());
         $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
         $this->assertFileDoesNotExist($this->databasePath . '.tmp');
+        $this->assertFileDoesNotExist(dirname($this->databasePath) . '/GeoLite2-City.mmdb.gz');
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
+    }
+
+    public function test_malformed_archive_keeps_existing_database_and_cleans_up_files()
+    {
+        Option::update('geoip_license_type', 'user-license');
+        Option::update('geoip_license_key', 'test-license-key');
+
+        add_filter('pre_http_request', function ($response, $args) {
+            file_put_contents($args['filename'], "\x1f\x8b\x08");
+
+            return [
+                'headers'  => [],
+                'body'     => '',
+                'response' => [
+                    'code'    => 200,
+                    'message' => 'OK',
+                ],
+                'cookies'  => [],
+            ];
+        }, 10, 2);
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('Failed to extract the database file', $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertFileDoesNotExist($this->databasePath . '.tmp');
+        $this->assertFileDoesNotExist(dirname($this->databasePath) . '/GeoLite2-City.mmdb.gz');
         $this->assertSame(12345, Option::get('last_geoip_dl'));
     }
 
@@ -88,6 +118,8 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertWPError($result);
         $this->assertStringContainsString('Connection failed.', $result->get_error_message());
         $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
 
         remove_all_filters('pre_http_request');
         add_filter('pre_http_request', function () {
@@ -107,6 +139,8 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertWPError($result);
         $this->assertStringContainsString('HTTP status code 403', $result->get_error_message());
         $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
     }
 
     public function test_cloudflare_download_is_a_successful_no_op()

--- a/tests/integration/Test_MaxmindGeoIPProvider.php
+++ b/tests/integration/Test_MaxmindGeoIPProvider.php
@@ -4,6 +4,8 @@ namespace WP_Statistics\Tests\Service\Geolocation\Provider;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
+use WP_Error;
+use WP_Statistics\Service\Geolocation\Provider\CloudflareGeolocationProvider;
 use WP_Statistics\Service\Geolocation\Provider\MaxmindGeoIPProvider;
 use WP_STATISTICS\Option;
 use WP_UnitTestCase;
@@ -68,5 +70,49 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
         $this->assertFileDoesNotExist($this->databasePath . '.tmp');
         $this->assertSame(12345, Option::get('last_geoip_dl'));
+    }
+
+    public function test_download_error_does_not_expose_maxmind_license_key()
+    {
+        $licenseKey = 'secret-license-key';
+
+        Option::update('geoip_license_type', 'user-license');
+        Option::update('geoip_license_key', $licenseKey);
+
+        add_filter('pre_http_request', function () {
+            return new WP_Error('http_request_failed', 'Connection failed.');
+        });
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('Connection failed.', $result->get_error_message());
+        $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+
+        remove_all_filters('pre_http_request');
+        add_filter('pre_http_request', function () {
+            return [
+                'headers'  => [],
+                'body'     => '',
+                'response' => [
+                    'code'    => 403,
+                    'message' => 'Forbidden',
+                ],
+                'cookies'  => [],
+            ];
+        });
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('HTTP status code 403', $result->get_error_message());
+        $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+    }
+
+    public function test_cloudflare_download_is_a_successful_no_op()
+    {
+        $provider = new CloudflareGeolocationProvider();
+
+        $this->assertTrue($provider->downloadDatabase());
     }
 }

--- a/tests/integration/Test_MaxmindGeoIPProvider.php
+++ b/tests/integration/Test_MaxmindGeoIPProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace WP_Statistics\Tests\Service\Geolocation\Provider;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use WP_Statistics\Service\Geolocation\Provider\MaxmindGeoIPProvider;
+use WP_STATISTICS\Option;
+use WP_UnitTestCase;
+
+class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
+{
+    private $provider;
+    private $databasePath;
+    private $originalDatabase = 'existing-invalid-database';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Option::update('geoip_location_detection_method', 'maxmind');
+        Option::update('geoip_license_type', 'js-deliver');
+        Option::update('last_geoip_dl', 12345);
+
+        $uploadDir          = wp_upload_dir();
+        $this->databasePath = $uploadDir['basedir'] . '/' . WP_STATISTICS_UPLOADS_DIR . '/GeoLite2-City.mmdb';
+
+        wp_mkdir_p(dirname($this->databasePath));
+        file_put_contents($this->databasePath, $this->originalDatabase);
+
+        $this->provider = new MaxmindGeoIPProvider();
+    }
+
+    public function tearDown(): void
+    {
+        remove_all_filters('pre_http_request');
+        wp_delete_file($this->databasePath);
+        wp_delete_file($this->databasePath . '.tmp');
+        wp_delete_file($this->databasePath . '.backup');
+        wp_delete_file(dirname($this->databasePath) . '/GeoLite2-City.mmdb.gz');
+
+        parent::tearDown();
+    }
+
+    public function test_corrupt_download_keeps_existing_database_and_returns_recovery_steps()
+    {
+        add_filter('pre_http_request', function ($response, $args) {
+            file_put_contents($args['filename'], gzencode('not-a-valid-mmdb'));
+
+            return [
+                'headers'  => [],
+                'body'     => '',
+                'response' => [
+                    'code'    => 200,
+                    'message' => 'OK',
+                ],
+                'cookies'  => [],
+            ];
+        }, 10, 2);
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('downloaded MaxMind GeoIP database is invalid', $result->get_error_message());
+        $this->assertStringContainsString('existing database was left unchanged', $result->get_error_message());
+        $this->assertStringContainsString('delete the MaxMind database and retry', $result->get_error_message());
+        $this->assertStringContainsString('switch to DB-IP', $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertFileDoesNotExist($this->databasePath . '.tmp');
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
+    }
+}


### PR DESCRIPTION
## What changed
- Download and extract MaxMind updates into a temporary file, then validate the MMDB reader and database type before replacing the active database.
- Preserve the current database and last-download timestamp when a download is corrupt or invalid, and return actionable recovery instructions.
- Surface server-provided AJAX errors in the settings UI and include the validation error message in Site Health diagnostics.
- Keep MaxMind license-bearing download URLs out of transport and HTTP-status error messages.
- Standardize the provider download contract as `bool|WP_Error`; Cloudflare reports its no-op download as a successful `true` result.
- Add focused regression coverage for corrupt and malformed downloads, credential-safe download failures, state preservation, cleanup, and the Cloudflare no-op contract.

## Why
A streamed download could previously overwrite the live database before its contents were validated. If extraction or reader initialization failed, Site Health showed only `Validation = No` / `error`, while transport failures could fall back to a generic admin message. Staging and validating first prevents a bad update from replacing the existing file and makes the failure and recovery path visible. Omitting the download URL also prevents a user-supplied MaxMind license key from reaching logs or browser-visible errors.

## Test
- `PATH="$(composer global config bin-dir --absolute --quiet):$PATH" phpunit --filter Test_MaxmindGeoIPProvider --testdox`
- Result: **OK (4 tests, 26 assertions)** on PHP 8.4.23.
- Note: the repository test bootstrap emits pre-existing warnings because `wptests_statistics_pages` is absent; the focused tests pass.
- `php -l` passed for all eight PHP files changed by the PR.
- `git diff --check origin/master...HEAD` passed.

## Manual verification
1. Configure MaxMind and trigger **Update GeoIP Database** with a corrupt/truncated download response.
2. Confirm the admin alert includes the underlying validation failure and the delete/redownload or DB-IP recovery options.
3. Confirm the prior database file and `last_geoip_dl` timestamp remain unchanged.
4. Check Site Health and confirm **GeoIP Database Validation** includes the specific validation error.
5. Configure a user MaxMind license and simulate a transport or non-200 response; confirm the error retains the failure detail without exposing the license-bearing URL.

Closes #1114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GeoIP database updates now validate downloaded files before replacing the active database.
  * Failed or corrupted downloads no longer overwrite a working database.
  * Temporary download files are cleaned up automatically after failures.
  * Error notifications now display clearer, more reliable messages.
  * Site Health diagnostics provide the full database error details, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

