### PR TITLE
Add a separate bot activity log

### DIFF
--- a/includes/admin/class-wp-statistics-admin-export.php
+++ b/includes/admin/class-wp-statistics-admin-export.php
@@ -48,6 +48,10 @@ class Export
                     $table = false;
                 }
 
+                if ($table && !DB::ExistTable(DB::table($table))) {
+                    $table = false;
+                }
+
                 // Validate the file type the user passed to us.
                 if (!($type == "xml" || $type == "csv" || $type == "tsv")) {
                     $table = false;

--- a/includes/admin/pages/class-wp-statistics-admin-page-settings.php
+++ b/includes/admin/pages/class-wp-statistics-admin-page-settings.php
@@ -8,6 +8,7 @@ use WP_Statistics\Components\AssetNameObfuscator;
 use WP_Statistics\Components\Singleton;
 use WP_Statistics\Service\Admin\NoticeHandler\Notice;
 use WP_Statistics\Service\Geolocation\GeolocationFactory;
+use WP_Statistics\Service\Analytics\BotActivity;
 use WP_Statistics\Utils\Request;
 
 class settings_page extends Singleton
@@ -304,6 +305,7 @@ class settings_page extends Singleton
         // Save Exclusion
         $wps_option_list = array(
             'wps_record_exclusions',
+            'wps_bot_activity',
             'wps_robotlist',
             'wps_query_params_allow_list',
             'wps_exclude_ip',
@@ -318,6 +320,11 @@ class settings_page extends Singleton
 
         foreach ($wps_option_list as $option) {
             $wp_statistics_options[self::input_name_to_option($option)] = (isset($_POST[$option]) ? sanitize_textarea_field($_POST[$option]) : '');
+        }
+
+        if (!empty($_POST['wps_bot_activity']) && !BotActivity::ensureTable()) {
+            $wp_statistics_options['bot_activity'] = '';
+            Notice::addFlashNotice(esc_html__('The bot activity log could not be enabled because its database table could not be created.', 'wp-statistics'), 'error');
         }
 
         return $wp_statistics_options;

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -104,6 +104,15 @@ use WP_STATISTICS\Option;
                     <p class="description"><?php echo esc_html__('Set a threshold for daily robot visits. Robots exceeding this number daily will be identified as bots.', 'wp-statistics'); ?></p>
                 </td>
             </tr>
+
+            <tr data-id="bot_activity_tr">
+                <th scope="row"><span class="wps-setting-label"><?php esc_html_e('Bot Activity Log', 'wp-statistics'); ?></span></th>
+                <td>
+                    <input id="wps-bot-activity" type="checkbox" value="1" name="wps_bot_activity" <?php checked(Option::get('bot_activity')); ?>>
+                    <label for="wps-bot-activity"><?php esc_html_e('Enable', 'wp-statistics'); ?></label>
+                    <p class="description"><?php esc_html_e('Keep a separate five-minute activity log for traffic excluded as robots, headless browsers, or by the robot view threshold. The log appears under Visitor Insights > Bot Activity and never changes normal visitor, online, view, or traffic totals. Stored IP addresses follow your privacy settings.', 'wp-statistics'); ?></p>
+                </td>
+            </tr>
             </tbody>
         </table>
     </div>

--- a/includes/admin/templates/settings/exclusions.php
+++ b/includes/admin/templates/settings/exclusions.php
@@ -110,7 +110,7 @@ use WP_STATISTICS\Option;
                 <td>
                     <input id="wps-bot-activity" type="checkbox" value="1" name="wps_bot_activity" <?php checked(Option::get('bot_activity')); ?>>
                     <label for="wps-bot-activity"><?php esc_html_e('Enable', 'wp-statistics'); ?></label>
-                    <p class="description"><?php esc_html_e('Keep a separate five-minute activity log for traffic excluded as robots, headless browsers, or by the robot view threshold. The log appears under Visitor Insights > Bot Activity and never changes normal visitor, online, view, or traffic totals. Stored IP addresses follow your privacy settings.', 'wp-statistics'); ?></p>
+                    <p class="description"><?php esc_html_e('Show the last five minutes of traffic excluded as robots, headless browsers, or by the robot view threshold. Stored records follow your configured data retention schedule, and the log never changes normal visitor, online, view, or traffic totals. Stored IP addresses follow your privacy settings.', 'wp-statistics'); ?></p>
                 </td>
             </tr>
             </tbody>

--- a/includes/class-wp-statistics-db.php
+++ b/includes/class-wp-statistics-db.php
@@ -17,6 +17,7 @@ class DB
          */
         'visitor',
         'exclusions',
+        'bot_activity',
         'pages',
         'historical',
         'visitor_relationships',
@@ -85,6 +86,7 @@ class DB
              */
             'visitor'               => __('This table keeps a record of individual visitors to your website. Each row represents a unique visitor\'s information and their activities.', 'wp-statistics'),
             'exclusions'            => __('This table logs views that have been excluded based on certain criteria, like bots or specific IP addresses. It helps keep your statistics clean from non-human or unwanted traffic.', 'wp-statistics'),
+            'bot_activity'          => __('This table stores recent bot activity separately from visitor and traffic statistics when the optional bot activity log is enabled.', 'wp-statistics'),
             'pages'                 => __('This table logs the number of views each page on your website receives. Each row represents the data for a specific page.', 'wp-statistics'),
             'historical'            => __('This table stores historical data about views and visitors over time. It\'s useful for tracking trends and patterns in your website\'s traffic.', 'wp-statistics'),
             'visitor_relationships' => __('This table captures the relationships between visitors and the content they interact with, helping you understand user behavior and preferences.', 'wp-statistics'),

--- a/includes/class-wp-statistics-exclusion.php
+++ b/includes/class-wp-statistics-exclusion.php
@@ -3,6 +3,7 @@
 namespace WP_STATISTICS;
 
 use WP_Statistics\Service\Analytics\VisitorProfile;
+use WP_Statistics\Service\Analytics\BotActivity;
 use WP_Statistics\Utils\Request;
 
 class Exclusion
@@ -94,11 +95,16 @@ class Exclusion
     /**
      * Record Exclusion in WP Statistics DB.
      *
-     * @param array $exclusion
+     * @param array               $exclusion
+     * @param VisitorProfile|null $visitorProfile
      */
-    public static function record($exclusion = array())
+    public static function record($exclusion = array(), $visitorProfile = null)
     {
         global $wpdb;
+
+        if ($visitorProfile instanceof VisitorProfile) {
+            BotActivity::record($exclusion, $visitorProfile);
+        }
 
         // If we're not storing exclusions, just return.
         if (self::record_active() != true) {

--- a/includes/class-wp-statistics-hits.php
+++ b/includes/class-wp-statistics-hits.php
@@ -193,7 +193,7 @@ class Hits extends Singleton
          * Record exclusion if needed & then skip the tracking
          */
         if ($exclusion['exclusion_match'] === true) {
-            Exclusion::record($exclusion);
+            Exclusion::record($exclusion, $visitorProfile);
             self::errorListener();
 
             // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- internal exception, message is not rendered to HTML

--- a/includes/class-wp-statistics-option.php
+++ b/includes/class-wp-statistics-option.php
@@ -39,6 +39,7 @@ class Option
 
         $options = array(
             'robotlist'                       => '',
+            'bot_activity'                    => false,
             'query_params_allow_list'         => Helper::get_default_query_params_allow_list('string'),
             'anonymize_ips'                   => true,
             'hash_ips'                        => true,

--- a/includes/class-wp-statistics-purge.php
+++ b/includes/class-wp-statistics-purge.php
@@ -107,6 +107,23 @@ class Purge
             }
 
             /**
+             * Purge the optional bot activity data.
+             */
+            $table_name = DB::table('bot_activity');
+
+            if (DB::ExistTable($table_name)) {
+                $result = $wpdb->query($wpdb->prepare("DELETE FROM {$table_name} WHERE `last_counter` < %s", $date_string));
+
+                if ($result) {
+                    /* translators: %1$s: string value, %2$s: string value */
+                    $result_string .= '<br>' . sprintf(__('Data from %1$s Older Than %2$s Days Successfully Purged.', 'wp-statistics'), '<code>' . $table_name . '</code>', '<code>' . $purge_days . '</code>');
+                } else {
+                    /* translators: %s: string value */
+                    $result_string .= '<br>' . sprintf(__('No Records to Purge from %s!', 'wp-statistics'), '<code>' . $table_name . '</code>');
+                }
+            }
+
+            /**
              * Purge the pages data, this is more complex as we want to save the historical data per page.
              */
             $table_name = DB::table('pages');

--- a/src/Models/BotActivityModel.php
+++ b/src/Models/BotActivityModel.php
@@ -3,7 +3,6 @@
 namespace WP_Statistics\Models;
 
 use WP_Statistics\Abstracts\BaseModel;
-use WP_Statistics\Components\DateTime;
 use WP_Statistics\Utils\Query;
 
 class BotActivityModel extends BaseModel
@@ -22,7 +21,7 @@ class BotActivityModel extends BaseModel
         ]);
 
         $this->timeframe = [
-            'from' => (int) DateTime::get('-' . absint($args['timeframe']) . ' min', 'U'),
+            'from' => time() - (absint($args['timeframe']) * MINUTE_IN_SECONDS),
         ];
     }
 

--- a/src/Models/BotActivityModel.php
+++ b/src/Models/BotActivityModel.php
@@ -24,7 +24,6 @@ class BotActivityModel extends BaseModel
 
         $this->timeframe = [
             'from' => (int) DateTime::get('-' . absint($args['timeframe']) . ' min', 'U'),
-            'to'   => (int) DateTime::get('now', 'U'),
         ];
     }
 
@@ -50,7 +49,6 @@ class BotActivityModel extends BaseModel
             ->where('ip', '=', $args['ip'])
             ->where('reason', '=', $args['reason'])
             ->where('last_view', '>=', $this->timeframe['from'])
-            ->where('last_view', '<=', $this->timeframe['to'])
             ->getVar();
 
         return $result ? (int) $result : 0;
@@ -82,7 +80,6 @@ class BotActivityModel extends BaseModel
             ->where('ip', '=', $args['ip'])
             ->where('reason', '=', $args['reason'])
             ->where('last_view', '>=', $this->timeframe['from'])
-            ->where('last_view', '<=', $this->timeframe['to'])
             ->perPage($args['page'], $args['per_page'])
             ->orderBy($args['order_by'], $args['order'])
             ->getAll();

--- a/src/Models/BotActivityModel.php
+++ b/src/Models/BotActivityModel.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace WP_Statistics\Models;
+
+use WP_STATISTICS\DB;
+use WP_Statistics\Abstracts\BaseModel;
+use WP_Statistics\Components\DateTime;
+use WP_Statistics\Utils\Query;
+
+class BotActivityModel extends BaseModel
+{
+    protected $timeframe;
+
+    /**
+     * @param array $args {
+     *     @type int $timeframe Timeframe in minutes. Default 5.
+     * }
+     */
+    public function __construct($args = [])
+    {
+        $args = wp_parse_args($args, [
+            'timeframe' => 5,
+        ]);
+
+        $this->timeframe = [
+            'from' => DateTime::get('-' . absint($args['timeframe']) . ' min', 'Y-m-d H:i:s'),
+            'to'   => DateTime::get('now', 'Y-m-d H:i:s'),
+        ];
+    }
+
+    /**
+     * Count recent bot activity records.
+     *
+     * @param array $args Query arguments.
+     * @return int
+     */
+    public function countActivities($args = [])
+    {
+        if (!DB::ExistTable(DB::table('bot_activity'))) {
+            return 0;
+        }
+
+        $args = $this->parseArgs($args, [
+            'ip'     => '',
+            'reason' => '',
+        ]);
+
+        $result = Query::select('COUNT(*)')
+            ->from('bot_activity')
+            ->where('ip', '=', $args['ip'])
+            ->where('reason', '=', $args['reason'])
+            ->whereDate('last_view', $this->timeframe)
+            ->getVar();
+
+        return $result ? (int) $result : 0;
+    }
+
+    /**
+     * Get recent bot activity records.
+     *
+     * @param array $args Query arguments.
+     * @return array
+     */
+    public function getActivities($args = [])
+    {
+        if (!DB::ExistTable(DB::table('bot_activity'))) {
+            return [];
+        }
+
+        $args = $this->parseArgs($args, [
+            'ip'       => '',
+            'reason'   => '',
+            'page'     => 1,
+            'per_page' => '',
+            'order_by' => 'last_view',
+            'order'    => 'DESC',
+        ]);
+
+        $result = Query::select('*')
+            ->from('bot_activity')
+            ->where('ip', '=', $args['ip'])
+            ->where('reason', '=', $args['reason'])
+            ->whereDate('last_view', $this->timeframe)
+            ->perPage($args['page'], $args['per_page'])
+            ->orderBy($args['order_by'], $args['order'])
+            ->getAll();
+
+        return $result ?: [];
+    }
+}

--- a/src/Models/BotActivityModel.php
+++ b/src/Models/BotActivityModel.php
@@ -23,8 +23,8 @@ class BotActivityModel extends BaseModel
         ]);
 
         $this->timeframe = [
-            'from' => DateTime::get('-' . absint($args['timeframe']) . ' min', 'Y-m-d H:i:s'),
-            'to'   => DateTime::get('now', 'Y-m-d H:i:s'),
+            'from' => (int) DateTime::get('-' . absint($args['timeframe']) . ' min', 'U'),
+            'to'   => (int) DateTime::get('now', 'U'),
         ];
     }
 
@@ -49,7 +49,8 @@ class BotActivityModel extends BaseModel
             ->from('bot_activity')
             ->where('ip', '=', $args['ip'])
             ->where('reason', '=', $args['reason'])
-            ->whereDate('last_view', $this->timeframe)
+            ->where('last_view', '>=', $this->timeframe['from'])
+            ->where('last_view', '<=', $this->timeframe['to'])
             ->getVar();
 
         return $result ? (int) $result : 0;
@@ -80,7 +81,8 @@ class BotActivityModel extends BaseModel
             ->from('bot_activity')
             ->where('ip', '=', $args['ip'])
             ->where('reason', '=', $args['reason'])
-            ->whereDate('last_view', $this->timeframe)
+            ->where('last_view', '>=', $this->timeframe['from'])
+            ->where('last_view', '<=', $this->timeframe['to'])
             ->perPage($args['page'], $args['per_page'])
             ->orderBy($args['order_by'], $args['order'])
             ->getAll();

--- a/src/Models/BotActivityModel.php
+++ b/src/Models/BotActivityModel.php
@@ -2,7 +2,6 @@
 
 namespace WP_Statistics\Models;
 
-use WP_STATISTICS\DB;
 use WP_Statistics\Abstracts\BaseModel;
 use WP_Statistics\Components\DateTime;
 use WP_Statistics\Utils\Query;
@@ -35,10 +34,6 @@ class BotActivityModel extends BaseModel
      */
     public function countActivities($args = [])
     {
-        if (!DB::ExistTable(DB::table('bot_activity'))) {
-            return 0;
-        }
-
         $args = $this->parseArgs($args, [
             'ip'     => '',
             'reason' => '',
@@ -62,10 +57,6 @@ class BotActivityModel extends BaseModel
      */
     public function getActivities($args = [])
     {
-        if (!DB::ExistTable(DB::table('bot_activity'))) {
-            return [];
-        }
-
         $args = $this->parseArgs($args, [
             'ip'       => '',
             'reason'   => '',

--- a/src/Service/Admin/VisitorInsights/Views/TabsView.php
+++ b/src/Service/Admin/VisitorInsights/Views/TabsView.php
@@ -18,6 +18,7 @@ use WP_Statistics\Service\Admin\VisitorInsights\VisitorInsightsDataProvider;
 class TabsView extends BaseTabView
 {
     private $isTrackLoggedInUsersEnabled;
+    private $isBotActivityEnabled;
     protected $defaultTab = 'overview';
     protected $tabs = [
         'overview',
@@ -31,9 +32,14 @@ class TabsView extends BaseTabView
     public function __construct()
     {
         $this->isTrackLoggedInUsersEnabled = Option::get('visitors_log') ? true : false;
+        $this->isBotActivityEnabled         = Option::get('bot_activity') ? true : false;
 
         if ($this->isTrackLoggedInUsersEnabled) {
             $this->tabs[] = 'logged-in-users';
+        }
+
+        if ($this->isBotActivityEnabled) {
+            $this->tabs[] = 'bot-activity';
         }
 
         $this->dataProvider = new VisitorInsightsDataProvider([
@@ -72,6 +78,11 @@ class TabsView extends BaseTabView
     public function getOnlineData()
     {
         return $this->dataProvider->getOnlineVisitorsData();
+    }
+
+    public function getBotActivityData()
+    {
+        return $this->dataProvider->getBotActivityData();
     }
 
     public function getTopVisitorsData()
@@ -134,6 +145,14 @@ class TabsView extends BaseTabView
 
                 ],
                 [
+                    'id'      => 'bot-activity',
+                    'link'    => Menus::admin_url('visitors', ['tab' => 'bot-activity']),
+                    'title'   => esc_html__('Bot Activity', 'wp-statistics'),
+                    'tooltip' => esc_html__('Review recently excluded bot traffic separately from normal visitor statistics.', 'wp-statistics'),
+                    'class'   => $this->isTab('bot-activity') ? 'current' : '',
+                    'hidden'  => !$this->isBotActivityEnabled,
+                ],
+                [
                     'id'     => 'top-visitors',
                     'link'   => Menus::admin_url('visitors', ['tab' => 'top-visitors']),
                     'title'  => esc_html__('Top Visitors', 'wp-statistics'),
@@ -182,7 +201,7 @@ class TabsView extends BaseTabView
             $args['tabs'] = $tabs;
         }
 
-        if ($this->isTab('online')) {
+        if ($this->isTab(['online', 'bot-activity'])) {
             $args['hasDateRang']        = false;
             $args['real_time_button']   = true;
         }

--- a/src/Service/Admin/VisitorInsights/VisitorInsightsDataProvider.php
+++ b/src/Service/Admin/VisitorInsights/VisitorInsightsDataProvider.php
@@ -7,6 +7,7 @@ use WP_STATISTICS\Admin_Template;
 use WP_Statistics\Utils\Request;
 use WP_Statistics\Models\ViewsModel;
 use WP_Statistics\Models\OnlineModel;
+use WP_Statistics\Models\BotActivityModel;
 use WP_Statistics\Components\DateRange;
 use WP_STATISTICS\Helper;
 use WP_Statistics\Models\VisitorsModel;
@@ -17,6 +18,7 @@ class VisitorInsightsDataProvider
     protected $args;
     protected $visitorsModel;
     protected $onlineModel;
+    protected $botActivityModel;
     protected $viewsModel;
 
     protected $isTrackLoggedInUsersEnabled;
@@ -29,9 +31,10 @@ class VisitorInsightsDataProvider
 
         $this->isTrackLoggedInUsersEnabled = Option::get('visitors_log') ? true : false;
 
-        $this->visitorsModel = new VisitorsModel();
-        $this->onlineModel   = new OnlineModel();
-        $this->viewsModel    = new ViewsModel();
+        $this->visitorsModel    = new VisitorsModel();
+        $this->onlineModel      = new OnlineModel();
+        $this->botActivityModel = new BotActivityModel();
+        $this->viewsModel       = new ViewsModel();
     }
 
     public function getOverviewData()
@@ -161,6 +164,20 @@ class VisitorInsightsDataProvider
                 'per_page'  => Admin_Template::$item_per_page
             ])),
             'total' => $this->onlineModel->countOnlines($this->args)
+        ];
+    }
+
+    public function getBotActivityData()
+    {
+        return [
+            'data'  => $this->botActivityModel->getActivities([
+                'ip'       => $this->args['ip'] ?? '',
+                'page'     => Admin_Template::getCurrentPaged(),
+                'per_page' => Admin_Template::$item_per_page,
+            ]),
+            'total' => $this->botActivityModel->countActivities([
+                'ip' => $this->args['ip'] ?? '',
+            ]),
         ];
     }
 

--- a/src/Service/Analytics/BotActivity.php
+++ b/src/Service/Analytics/BotActivity.php
@@ -87,7 +87,7 @@ class BotActivity
         $botName     = self::limit(self::getBotName($visitorProfile, $reason), 180);
         $activityKey = md5($ip . '|' . $userAgent . '|' . $uri);
         $date        = DateTime::get();
-        $lastView    = (int) DateTime::get('now', 'U');
+        $lastView    = time();
         $tableName   = DB::table('bot_activity');
 
         $recorded = $wpdb->query(

--- a/src/Service/Analytics/BotActivity.php
+++ b/src/Service/Analytics/BotActivity.php
@@ -87,12 +87,12 @@ class BotActivity
         $botName     = self::limit(self::getBotName($visitorProfile, $reason), 180);
         $activityKey = md5($ip . '|' . $userAgent . '|' . $uri);
         $date        = DateTime::get();
-        $lastView    = DateTime::get('now', 'Y-m-d H:i:s');
+        $lastView    = (int) DateTime::get('now', 'U');
         $tableName   = DB::table('bot_activity');
 
         $recorded = $wpdb->query(
             $wpdb->prepare(
-                "INSERT INTO `{$tableName}` (`last_counter`, `activity_key`, `ip`, `user_agent`, `bot_name`, `reason`, `uri`, `hits`, `last_view`) VALUES (%s, %s, %s, %s, %s, %s, %s, 1, %s) ON DUPLICATE KEY UPDATE `hits` = `hits` + 1, `last_view` = VALUES(`last_view`), `reason` = VALUES(`reason`), `bot_name` = VALUES(`bot_name`)",
+                "INSERT INTO `{$tableName}` (`last_counter`, `activity_key`, `ip`, `user_agent`, `bot_name`, `reason`, `uri`, `hits`, `last_view`) VALUES (%s, %s, %s, %s, %s, %s, %s, 1, %d) ON DUPLICATE KEY UPDATE `hits` = `hits` + 1, `last_view` = VALUES(`last_view`), `reason` = VALUES(`reason`), `bot_name` = VALUES(`bot_name`)",
                 $date,
                 $activityKey,
                 $ip,

--- a/src/Service/Analytics/BotActivity.php
+++ b/src/Service/Analytics/BotActivity.php
@@ -81,10 +81,11 @@ class BotActivity
 
         $requestUri  = $visitorProfile->getRequestUri();
         $requestPath = wp_parse_url($requestUri, PHP_URL_PATH);
-        $userAgent   = self::limit(sanitize_text_field($visitorProfile->getHttpUserAgent()), 190);
         $ip          = self::limit(sanitize_text_field($visitorProfile->getProcessedIPForStorage()), 60);
         $uri         = self::limit(sanitize_text_field($requestPath ?: '/'), 190);
         $botName     = self::limit(self::getBotName($visitorProfile, $reason), 180);
+        $rawAgent    = Option::get('store_ua') ? $visitorProfile->getHttpUserAgent() : $botName;
+        $userAgent   = self::limit(sanitize_text_field($rawAgent), 190);
         $activityKey = md5($ip . '|' . $userAgent . '|' . $uri);
         $date        = DateTime::get();
         $lastView    = time();

--- a/src/Service/Analytics/BotActivity.php
+++ b/src/Service/Analytics/BotActivity.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace WP_Statistics\Service\Analytics;
+
+use WP_STATISTICS\DB;
+use WP_STATISTICS\Option;
+use WP_Statistics\Components\DateTime;
+use WP_Statistics\Service\Analytics\DeviceDetection\UserAgentService;
+use WP_Statistics\Service\Database\Managers\TableHandler;
+use WP_Statistics\Service\Database\Schema\Manager;
+
+class BotActivity
+{
+    /**
+     * Exclusion reasons that represent bot or automated traffic.
+     *
+     * @var string[]
+     */
+    private static $botReasons = ['robot', 'headless', 'robot_threshold'];
+
+    /**
+     * Whether the separate bot activity log is enabled.
+     *
+     * @return bool
+     */
+    public static function isEnabled()
+    {
+        return (bool) Option::get('bot_activity', false);
+    }
+
+    /**
+     * Determine whether an exclusion reason represents bot activity.
+     *
+     * @param string $reason Exclusion reason.
+     * @return bool
+     */
+    public static function isBotReason($reason)
+    {
+        return in_array($reason, self::$botReasons, true);
+    }
+
+    /**
+     * Create the activity table when the feature is first enabled.
+     *
+     * @return bool
+     */
+    public static function ensureTable()
+    {
+        $tableName = DB::table('bot_activity');
+
+        if (DB::ExistTable($tableName)) {
+            return true;
+        }
+
+        try {
+            TableHandler::createTable('bot_activity', Manager::getSchemaForTable('bot_activity'));
+        } catch (\Exception $e) {
+            \WP_Statistics::log($e->getMessage(), 'warning');
+            return false;
+        }
+
+        return DB::ExistTable($tableName);
+    }
+
+    /**
+     * Store a recent bot hit separately from normal visitor statistics.
+     *
+     * @param array          $exclusion     Exclusion result.
+     * @param VisitorProfile $visitorProfile Visitor profile for the request.
+     * @return bool
+     */
+    public static function record($exclusion, VisitorProfile $visitorProfile)
+    {
+        global $wpdb;
+
+        $reason = isset($exclusion['exclusion_reason']) ? sanitize_key($exclusion['exclusion_reason']) : '';
+
+        if (!self::isEnabled() || !self::isBotReason($reason)) {
+            return false;
+        }
+
+        $requestUri  = $visitorProfile->getRequestUri();
+        $requestPath = wp_parse_url($requestUri, PHP_URL_PATH);
+        $userAgent   = self::limit(sanitize_text_field($visitorProfile->getHttpUserAgent()), 190);
+        $ip          = self::limit(sanitize_text_field($visitorProfile->getProcessedIPForStorage()), 60);
+        $uri         = self::limit(sanitize_text_field($requestPath ?: '/'), 190);
+        $botName     = self::limit(self::getBotName($visitorProfile, $reason), 180);
+        $activityKey = md5($ip . '|' . $userAgent . '|' . $uri);
+        $date        = DateTime::get();
+        $lastView    = DateTime::get('now', 'Y-m-d H:i:s');
+        $tableName   = DB::table('bot_activity');
+
+        $recorded = $wpdb->query(
+            $wpdb->prepare(
+                "INSERT INTO `{$tableName}` (`last_counter`, `activity_key`, `ip`, `user_agent`, `bot_name`, `reason`, `uri`, `hits`, `last_view`) VALUES (%s, %s, %s, %s, %s, %s, %s, 1, %s) ON DUPLICATE KEY UPDATE `hits` = `hits` + 1, `last_view` = VALUES(`last_view`), `reason` = VALUES(`reason`), `bot_name` = VALUES(`bot_name`)",
+                $date,
+                $activityKey,
+                $ip,
+                $userAgent,
+                $botName,
+                $reason,
+                $uri,
+                $lastView
+            )
+        );
+
+        if ($recorded === false) {
+            \WP_Statistics::log($wpdb->last_error, 'warning');
+            return false;
+        }
+
+        do_action('wp_statistics_save_bot_activity', $exclusion, $visitorProfile);
+
+        return true;
+    }
+
+    /**
+     * Resolve a human-readable name when Device Detector knows the bot.
+     *
+     * @param VisitorProfile $visitorProfile Visitor profile for the request.
+     * @param string         $reason         Exclusion reason.
+     * @return string
+     */
+    private static function getBotName(VisitorProfile $visitorProfile, $reason)
+    {
+        $userAgent = $visitorProfile->getUserAgent();
+
+        if (empty($userAgent)) {
+            return '';
+        }
+
+        $detector = $userAgent->getDeviceDetector();
+
+        if ($detector && $detector->isBot()) {
+            $bot = $detector->getBot();
+
+            if (!empty($bot['name'])) {
+                return UserAgentService::sanitizeDetectorValue($bot['name']);
+            }
+        }
+
+        if ($reason === 'headless') {
+            return UserAgentService::sanitizeDetectorValue($userAgent->getBrowser());
+        }
+
+        return '';
+    }
+
+    /**
+     * Limit values to their database column length.
+     *
+     * @param string $value  Value to limit.
+     * @param int    $length Maximum length.
+     * @return string
+     */
+    private static function limit($value, $length)
+    {
+        if (function_exists('mb_substr')) {
+            return mb_substr((string) $value, 0, $length);
+        }
+
+        return substr((string) $value, 0, $length);
+    }
+}

--- a/src/Service/CustomEvent/CustomEventActions.php
+++ b/src/Service/CustomEvent/CustomEventActions.php
@@ -36,7 +36,7 @@ class CustomEventActions
 
             $exclusion = Exclusion::check($visitorProfile);
             if ($exclusion['exclusion_match'] === true) {
-                Exclusion::record($exclusion);
+                Exclusion::record($exclusion, $visitorProfile);
 
                 throw new Exception($exclusion['exclusion_reason']);
             }

--- a/src/Service/Database/Schema/Manager.php
+++ b/src/Service/Database/Schema/Manager.php
@@ -99,6 +99,25 @@ class Manager
                 'reason' => 'KEY reason (reason)',
             ],
         ],
+        'bot_activity'          => [
+            'columns'     => [
+                'ID'           => 'bigint(20) NOT NULL AUTO_INCREMENT',
+                'last_counter' => 'date NOT NULL',
+                'activity_key' => 'char(32) NOT NULL',
+                'ip'           => 'varchar(60) NOT NULL',
+                'user_agent'   => 'varchar(190) NOT NULL',
+                'bot_name'     => 'varchar(180) DEFAULT NULL',
+                'reason'       => 'varchar(50) NOT NULL',
+                'uri'          => 'varchar(190) NOT NULL',
+                'hits'         => 'bigint(20) NOT NULL',
+                'last_view'    => 'datetime NOT NULL',
+            ],
+            'constraints' => [
+                'ID'               => 'PRIMARY KEY (ID)',
+                'last_view'        => 'KEY last_view (last_view)',
+                'date_activity_key' => 'UNIQUE KEY date_activity_key (last_counter, activity_key)',
+            ],
+        ],
         'events'                => [
             'columns'     => [
                 'ID'         => 'bigint(20) NOT NULL AUTO_INCREMENT',

--- a/src/Service/Database/Schema/Manager.php
+++ b/src/Service/Database/Schema/Manager.php
@@ -113,8 +113,9 @@ class Manager
                 'last_view'    => 'bigint(20) NOT NULL',
             ],
             'constraints' => [
-                'ID'               => 'PRIMARY KEY (ID)',
-                'last_view'        => 'KEY last_view (last_view)',
+                'ID'                => 'PRIMARY KEY (ID)',
+                'last_view'         => 'KEY last_view (last_view)',
+                'activity_filters'  => 'KEY activity_filters (ip, reason, last_view)',
                 'date_activity_key' => 'UNIQUE KEY date_activity_key (last_counter, activity_key)',
             ],
         ],

--- a/src/Service/Database/Schema/Manager.php
+++ b/src/Service/Database/Schema/Manager.php
@@ -110,7 +110,7 @@ class Manager
                 'reason'       => 'varchar(50) NOT NULL',
                 'uri'          => 'varchar(190) NOT NULL',
                 'hits'         => 'bigint(20) NOT NULL',
-                'last_view'    => 'datetime NOT NULL',
+                'last_view'    => 'bigint(20) NOT NULL',
             ],
             'constraints' => [
                 'ID'               => 'PRIMARY KEY (ID)',

--- a/tests/integration/Test_BotActivity.php
+++ b/tests/integration/Test_BotActivity.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace WP_Statistics\Tests;
+
+use WP_STATISTICS\DB;
+use WP_STATISTICS\Exclusion;
+use WP_STATISTICS\Option;
+use WP_Statistics\Models\BotActivityModel;
+use WP_Statistics\Service\Analytics\BotActivity;
+use WP_Statistics\Service\Analytics\DeviceDetection\UserAgentService;
+use WP_Statistics\Service\Analytics\VisitorProfile;
+use WP_UnitTestCase;
+
+class Test_BotActivity extends WP_UnitTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        BotActivity::ensureTable();
+        Option::update('bot_activity', false);
+        Option::update('record_exclusions', false);
+
+        global $wpdb;
+        $wpdb->query('TRUNCATE TABLE `' . DB::table('bot_activity') . '`');
+    }
+
+    public function tearDown(): void
+    {
+        Option::update('bot_activity', false);
+        parent::tearDown();
+    }
+
+    public function test_records_only_enabled_bot_exclusions_and_updates_recent_activity()
+    {
+        global $wpdb;
+
+        $profile = $this->createVisitorProfile();
+        $table   = DB::table('bot_activity');
+
+        Exclusion::record(['exclusion_reason' => 'robot'], $profile);
+        $this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`"));
+
+        Option::update('bot_activity', true);
+
+        Exclusion::record(['exclusion_reason' => 'excluded url'], $profile);
+        $this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`"));
+
+        Exclusion::record(['exclusion_reason' => 'robot'], $profile);
+
+        $activity = $wpdb->get_row("SELECT * FROM `{$table}`");
+
+        $this->assertNotNull($activity);
+        $this->assertSame('robot', $activity->reason);
+        $this->assertSame('203.0.113.8', $activity->ip);
+        $this->assertSame('ExampleBot/1.0', $activity->user_agent);
+        $this->assertSame('/products', $activity->uri);
+        $this->assertSame('1', $activity->hits);
+
+        Exclusion::record(['exclusion_reason' => 'robot'], $profile);
+
+        $this->assertSame('1', $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`"));
+        $this->assertSame('2', $wpdb->get_var("SELECT hits FROM `{$table}`"));
+
+        $model      = new BotActivityModel();
+        $activities = $model->getActivities();
+
+        $this->assertSame(1, $model->countActivities());
+        $this->assertCount(1, $activities);
+        $this->assertSame('robot', $activities[0]->reason);
+    }
+
+    private function createVisitorProfile()
+    {
+        $userAgent = $this->createMock(UserAgentService::class);
+        $userAgent->method('getDeviceDetector')->willReturn(null);
+
+        $profile = $this->getMockBuilder(VisitorProfile::class)
+            ->onlyMethods([
+                'getHttpUserAgent',
+                'getProcessedIPForStorage',
+                'getRequestUri',
+                'getUserAgent',
+            ])
+            ->getMock();
+
+        $profile->method('getHttpUserAgent')->willReturn('ExampleBot/1.0');
+        $profile->method('getProcessedIPForStorage')->willReturn('203.0.113.8');
+        $profile->method('getRequestUri')->willReturn('/products?token=secret');
+        $profile->method('getUserAgent')->willReturn($userAgent);
+
+        return $profile;
+    }
+}

--- a/tests/integration/Test_BotActivity.php
+++ b/tests/integration/Test_BotActivity.php
@@ -5,6 +5,7 @@ namespace WP_Statistics\Tests;
 use WP_STATISTICS\DB;
 use WP_STATISTICS\Exclusion;
 use WP_STATISTICS\Option;
+use WP_Statistics\Components\DateTime;
 use WP_Statistics\Models\BotActivityModel;
 use WP_Statistics\Service\Analytics\BotActivity;
 use WP_Statistics\Service\Analytics\DeviceDetection\UserAgentService;
@@ -68,6 +69,26 @@ class Test_BotActivity extends WP_UnitTestCase
         $this->assertSame(1, $model->countActivities());
         $this->assertCount(1, $activities);
         $this->assertSame('robot', $activities[0]->reason);
+    }
+
+    public function test_includes_recent_activity_at_the_upper_time_boundary()
+    {
+        global $wpdb;
+
+        Option::update('bot_activity', true);
+        Exclusion::record(['exclusion_reason' => 'robot'], $this->createVisitorProfile());
+
+        $table = DB::table('bot_activity');
+        $wpdb->update(
+            $table,
+            ['last_view' => (int) DateTime::get('+1 second', 'U')],
+            ['ID' => $wpdb->get_var("SELECT ID FROM `{$table}`")]
+        );
+
+        $model = new BotActivityModel();
+
+        $this->assertSame(1, $model->countActivities());
+        $this->assertCount(1, $model->getActivities());
     }
 
     private function createVisitorProfile()

--- a/tests/integration/Test_BotActivity.php
+++ b/tests/integration/Test_BotActivity.php
@@ -20,6 +20,7 @@ class Test_BotActivity extends WP_UnitTestCase
         BotActivity::ensureTable();
         Option::update('bot_activity', false);
         Option::update('record_exclusions', false);
+        Option::update('store_ua', false);
 
         global $wpdb;
         $wpdb->query('TRUNCATE TABLE `' . DB::table('bot_activity') . '`');
@@ -28,6 +29,7 @@ class Test_BotActivity extends WP_UnitTestCase
     public function tearDown(): void
     {
         Option::update('bot_activity', false);
+        Option::update('store_ua', false);
         parent::tearDown();
     }
 
@@ -42,6 +44,7 @@ class Test_BotActivity extends WP_UnitTestCase
         $this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`"));
 
         Option::update('bot_activity', true);
+        Option::update('store_ua', true);
 
         Exclusion::record(['exclusion_reason' => 'excluded url'], $profile);
         $this->assertSame('0', $wpdb->get_var("SELECT COUNT(*) FROM `{$table}`"));
@@ -68,6 +71,28 @@ class Test_BotActivity extends WP_UnitTestCase
         $this->assertSame(1, $model->countActivities());
         $this->assertCount(1, $activities);
         $this->assertSame('robot', $activities[0]->reason);
+        $this->assertSame(1, $model->countActivities(['ip' => '203.0.113.8', 'reason' => 'robot']));
+        $this->assertSame(0, $model->countActivities(['reason' => 'headless']));
+    }
+
+    public function test_respects_user_agent_storage_setting()
+    {
+        global $wpdb;
+
+        Option::update('bot_activity', true);
+
+        $profile = $this->createVisitorProfile();
+        $table   = DB::table('bot_activity');
+
+        Exclusion::record(['exclusion_reason' => 'robot'], $profile);
+        $this->assertSame('', $wpdb->get_row("SELECT * FROM `{$table}`")->user_agent);
+
+        Option::update('store_ua', true);
+        Exclusion::record(['exclusion_reason' => 'robot'], $profile);
+
+        $activities = $wpdb->get_results("SELECT * FROM `{$table}` ORDER BY ID");
+        $this->assertSame('', $activities[0]->user_agent);
+        $this->assertSame('ExampleBot/1.0', $activities[1]->user_agent);
     }
 
     public function test_includes_recent_activity_at_the_upper_time_boundary()

--- a/tests/integration/Test_BotActivity.php
+++ b/tests/integration/Test_BotActivity.php
@@ -5,7 +5,6 @@ namespace WP_Statistics\Tests;
 use WP_STATISTICS\DB;
 use WP_STATISTICS\Exclusion;
 use WP_STATISTICS\Option;
-use WP_Statistics\Components\DateTime;
 use WP_Statistics\Models\BotActivityModel;
 use WP_Statistics\Service\Analytics\BotActivity;
 use WP_Statistics\Service\Analytics\DeviceDetection\UserAgentService;
@@ -81,7 +80,7 @@ class Test_BotActivity extends WP_UnitTestCase
         $table = DB::table('bot_activity');
         $wpdb->update(
             $table,
-            ['last_view' => (int) DateTime::get('+1 second', 'U')],
+            ['last_view' => time() + 1],
             ['ID' => $wpdb->get_var("SELECT ID FROM `{$table}`")]
         );
 

--- a/views/pages/visitor-insights/bot-activity.php
+++ b/views/pages/visitor-insights/bot-activity.php
@@ -1,0 +1,65 @@
+<?php
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use WP_Statistics\Components\DateTime;
+use WP_STATISTICS\Exclusion;
+
+$reasons = Exclusion::exclusion_list();
+?>
+
+<div class="postbox-container wps-postbox-full">
+    <div class="notice notice-info inline">
+        <p>
+            <strong><?php esc_html_e('Bot Activity', 'wp-statistics'); ?>:</strong>
+            <?php esc_html_e('This separate log shows traffic excluded as bots during the last five minutes. It is not included in Online Visitors, visitor, view, or traffic totals.', 'wp-statistics'); ?>
+        </p>
+    </div>
+
+    <div class="metabox-holder">
+        <div class="meta-box-sortables">
+            <div class="postbox">
+                <div class="inside">
+                    <?php if (!empty($data['data'])) : ?>
+                        <div class="o-table-wrapper">
+                            <table width="100%" class="o-table wps-new-table">
+                                <thead>
+                                <tr>
+                                    <th scope="col" class="wps-pd-l"><?php esc_html_e('Last Activity', 'wp-statistics'); ?></th>
+                                    <th scope="col" class="wps-pd-l"><?php esc_html_e('Bot', 'wp-statistics'); ?></th>
+                                    <th scope="col" class="wps-pd-l"><?php esc_html_e('Exclusion Reason', 'wp-statistics'); ?></th>
+                                    <th scope="col" class="wps-pd-l"><?php esc_html_e('IP Address', 'wp-statistics'); ?></th>
+                                    <th scope="col" class="wps-pd-l"><?php esc_html_e('Requested URL', 'wp-statistics'); ?></th>
+                                    <th scope="col" class="wps-pd-l"><?php esc_html_e('Hits', 'wp-statistics'); ?></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <?php foreach ($data['data'] as $activity) : ?>
+                                    <tr>
+                                        <td class="wps-pd-l"><?php echo esc_html(DateTime::format($activity->last_view, ['include_time' => true])); ?></td>
+                                        <td class="wps-pd-l">
+                                            <strong><?php echo esc_html($activity->bot_name ?: __('Detected bot', 'wp-statistics')); ?></strong>
+                                            <?php if (!empty($activity->user_agent)) : ?>
+                                                <br><small><?php echo esc_html($activity->user_agent); ?></small>
+                                            <?php endif; ?>
+                                        </td>
+                                        <td class="wps-pd-l"><?php echo esc_html($reasons[$activity->reason] ?? $activity->reason); ?></td>
+                                        <td class="wps-pd-l"><code><?php echo esc_html($activity->ip); ?></code></td>
+                                        <td class="wps-pd-l"><code><?php echo esc_html($activity->uri ?: '/'); ?></code></td>
+                                        <td class="wps-pd-l"><?php echo esc_html(number_format_i18n($activity->hits)); ?></td>
+                                    </tr>
+                                <?php endforeach; ?>
+                                </tbody>
+                            </table>
+                        </div>
+                    <?php else : ?>
+                        <div class="o-wrap o-wrap--no-data wps-center">
+                            <?php esc_html_e('No bot activity detected in the last five minutes.', 'wp-statistics'); ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+                <?php echo isset($pagination) ? $pagination : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
> **Status:** Closed without merge after the maintainer decided this feature is not needed at this time.

## What changed
- Added a default-off **Bot Activity Log** setting under Exclusions.
- Records robot, headless-browser, and robot-threshold activity in a separate table without adding those requests to normal visitor, online, view, or traffic totals.
- Added a five-minute **Visitor Insights > Bot Activity** view with processed IP, optional full user agent, requested path, exclusion reason, hit count, and last activity time.
- Respects existing IP, full user-agent, and data-retention settings.
- Added focused integration coverage for disabled/non-bot behavior, storage, privacy, aggregation, filtering, query-string removal, recent activity retrieval, and the upper time boundary.

## Why
Users need a supported way to inspect recent crawler activity without editing plugin files or contaminating normal visitor statistics.

## How to test
1. Open **Statistics > Settings > Exclusions** and enable **Bot Activity Log**.
2. Send a request from a user agent matched by the custom bot list, headless detection, or robot threshold.
3. Open **Visitor Insights > Bot Activity** and confirm the request appears.
4. Confirm normal Online Visitors and traffic totals do not include the excluded request.
5. Disable full user-agent storage and confirm the bot record does not retain the raw user-agent string.

## Automated test
`phpunit --testdox tests/integration/Test_BotActivity.php` — passes (3 tests, 20 assertions) at the PR's final head.

The focused PHPUnit run completes successfully; this sandbox's repository bootstrap also emits its existing missing `wptests_statistics_pages` cleanup warnings.

Closes #1116