### PR TITLE
Release 14.16.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 14.16.11 - Unreleased
 - **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
+- **Enhancement:** Reduced admin dashboard work by skipping statistics metabox discovery and assets for users without statistics access.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 14.16.11 - Unreleased
+- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
-- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 14.16.9 - 2026-07-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-14.16.11 - Unreleased
-- **Fix:** Email report schedules now update when the configured report frequency changes.
-- **New:** Added a site-wide Bounce Rate to the Visitor Insights overview and a Bounce Rate column to the entry pages reports. Bounce rate is the share of visits that viewed only one page, where a visit is one visitor on one day.
-- **Enhancement:** Bounce rate is now counted from the stored per-visit page count instead of scanning the visitor-page relationships table, so the reports load faster and cache correctly. Existing per-content bounce rates may shift slightly.
-- **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
-- **Enhancement:** Reduced admin dashboard work by skipping statistics metabox discovery and assets for users without statistics access.
-- **Enhancement:** Tested up to WordPress v7.1.
+14.16.11 - 2026-08-22
+- **New:** Bounce Rate in Visitor Insights and a Bounce Rate column in the Entry Pages report.
+- **Enhancement:** Faster bounce rate calculation. Existing per-content bounce rates may shift slightly.
+- **Enhancement:** New `wp_statistics_online_visitors_timeframe` filter to set how long a visitor counts as online.
+- **Enhancement:** Lighter admin dashboard for users without statistics access.
+- **Fix:** Email report schedules now update when the report frequency changes.
+- **Enhancement:** Tested up to WordPress 7.1.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 14.16.11 - Unreleased
 - **Fix:** Email report schedules now update when the configured report frequency changes.
+- **New:** Added a site-wide Bounce Rate to the Visitor Insights overview and a Bounce Rate column to the entry pages reports. Bounce rate is the share of visits that viewed only one page, where a visit is one visitor on one day.
+- **Enhancement:** Bounce rate is now counted from the stored per-visit page count instead of scanning the visitor-page relationships table, so the reports load faster and cache correctly. Existing per-content bounce rates may shift slightly.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
 - **Enhancement:** Reduced admin dashboard work by skipping statistics metabox discovery and assets for users without statistics access.
 - **Enhancement:** Tested up to WordPress v7.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
 - **Enhancement:** Reduced admin dashboard work by skipping statistics metabox discovery and assets for users without statistics access.
+- **Enhancement:** Tested up to WordPress v7.1.
 
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.11 - Unreleased
+- **Enhancement:** Added the `wp_statistics_online_visitors_timeframe` filter to change how many minutes a visitor counts as online. The window was fixed at 5 minutes, so sites that wanted a different value had to edit the plugin after every update; the filter now holds through updates.
+
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
 - **Enhancement:** General security hardening and internal improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 14.16.10 - 2026-07-25
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
+- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 14.16.9 - 2026-07-21

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -508,7 +508,7 @@ class Admin_Assets
         // For developers: WordPress debugging mode.
         $list['wp_debug'] = defined('WP_DEBUG') && WP_DEBUG ? true : false;
 
-        $list['meta_boxes'] = MetaboxHelper::getScreenMetaboxes();
+        $list['meta_boxes'] = User::Access('read') ? MetaboxHelper::getScreenMetaboxes() : [];
 
         $list['wps_page'] = Context::get('wps_page');
 

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -144,6 +144,9 @@ class Admin_Assets
      */
     public function admin_styles()
     {
+        if (!User::Access()) {
+            return;
+        }
 
         // Get Current Screen ID
         $screen_id = Helper::get_screen_id();
@@ -185,6 +188,9 @@ class Admin_Assets
      */
     public function admin_scripts($hook)
     {
+        if (!User::Access()) {
+            return;
+        }
 
         // Get Current Screen ID
         $screen_id = Helper::get_screen_id();

--- a/includes/admin/templates/pages/content-analytics/single.php
+++ b/includes/admin/templates/pages/content-analytics/single.php
@@ -45,7 +45,7 @@ $postType = get_post_type($postId);
                 'value'    => $data['glance']['bounce_rate']['value'],
                 'change'   => $data['glance']['bounce_rate']['change'],
                 'polarity' => 'negative',
-                'tooltip'  => esc_html__('Percentage of single-page sessions that began and ended on this content.', 'wp-statistics'),
+                'tooltip'  => esc_html__('Share of visits that landed on this content and viewed no other page. A visit is one visitor on one day.', 'wp-statistics'),
             ],
             [
                 'label'    => esc_html__('Exit Rate', 'wp-statistics'),

--- a/includes/admin/templates/settings/advanced.php
+++ b/includes/admin/templates/settings/advanced.php
@@ -383,10 +383,17 @@ add_thickbox();
                         geoipClickedButton.classList.remove('wps-loading-button');
                         var alertClass = result.success ? 'wps-alert__success' : 'wps-alert__danger';
                         var message = result.data && result.data.message ? result.data.message : '';
-                        jQuery(geoipClickedButton).after("<div class='wps-alert wps-alert-box " + alertClass + "'><span>" + message + "</span></div>");
-                    }).fail(function () {
+                        var alert = jQuery("<div class='wps-alert wps-alert-box " + alertClass + "'><span></span></div>");
+                        alert.find('span').text(message);
+                        jQuery(geoipClickedButton).after(alert);
+                    }).fail(function (xhr) {
                         geoipClickedButton.classList.remove('wps-loading-button');
-                        jQuery(geoipClickedButton).after("<div class='wps-alert wps-alert-box wps-alert__danger'><span><?php esc_html_e('Oops! Something went wrong. Please try again. For more details, check the PHP Error Log.', 'wp-statistics'); ?></span></div>");
+                        var message = xhr.responseJSON && xhr.responseJSON.data && xhr.responseJSON.data.message
+                            ? xhr.responseJSON.data.message
+                            : '<?php echo esc_js(__('Oops! Something went wrong. Please try again. For more details, check the PHP Error Log.', 'wp-statistics')); ?>';
+                        var alert = jQuery("<div class='wps-alert wps-alert-box wps-alert__danger'><span></span></div>");
+                        alert.find('span').text(message);
+                        jQuery(geoipClickedButton).after(alert);
                     });
                 });
             });

--- a/includes/class-wp-statistics-geoip.php
+++ b/includes/class-wp-statistics-geoip.php
@@ -42,7 +42,7 @@ class GeoIP
     /**
      * Downloads the GeoIP database from MaxMind.
      *
-     * @return mixed Array containing status and notice messages.
+     * @return bool|\WP_Error True on success, or WP_Error on failure.
      * @deprecated This method is deprecated and should not be used in new development. use GeolocationFactory::downloadDatabase() instead.
      */
     public static function download()

--- a/includes/class-wp-statistics-schedule.php
+++ b/includes/class-wp-statistics-schedule.php
@@ -58,20 +58,23 @@ class Schedule
             wp_schedule_event(time(), 'monthly', 'wp_statistics_referrals_db_hook');
         }
 
+        $timeReports          = Option::get('time_report');
+        $scheduledReportEvent = wp_get_scheduled_event('wp_statistics_report_hook');
+
+        // Remove the report schedule if its frequency has changed or reports are disabled.
+        if ($scheduledReportEvent && $scheduledReportEvent->schedule !== $timeReports) {
+            wp_unschedule_event($scheduledReportEvent->timestamp, 'wp_statistics_report_hook');
+            $scheduledReportEvent = false;
+        }
+
         // Add the report schedule if it doesn't exist and is enabled.
-        if (!wp_next_scheduled('wp_statistics_report_hook') && Option::get('time_report') != '0') {
-            $timeReports       = Option::get('time_report');
+        if (!$scheduledReportEvent && $timeReports != '0') {
             $schedulesInterval = self::getSchedules();
 
             if (isset($schedulesInterval[$timeReports], $schedulesInterval[$timeReports]['next_schedule'])) {
                 $scheduleTime = $schedulesInterval[$timeReports]['next_schedule'];
                 wp_schedule_event($scheduleTime, $timeReports, 'wp_statistics_report_hook');
             }
-        }
-
-        // Remove the report schedule if it does exist and is disabled.
-        if (wp_next_scheduled('wp_statistics_report_hook') && Option::get('time_report') == '0') {
-            wp_unschedule_event(wp_next_scheduled('wp_statistics_report_hook'), 'wp_statistics_report_hook');
         }
 
         // Schedule license migration

--- a/includes/class-wp-statistics-schedule.php
+++ b/includes/class-wp-statistics-schedule.php
@@ -63,8 +63,9 @@ class Schedule
 
         // Remove the report schedule if its frequency has changed or reports are disabled.
         if ($scheduledReportEvent && $scheduledReportEvent->schedule !== $timeReports) {
-            wp_unschedule_event($scheduledReportEvent->timestamp, 'wp_statistics_report_hook');
-            $scheduledReportEvent = false;
+            if (wp_unschedule_event($scheduledReportEvent->timestamp, 'wp_statistics_report_hook')) {
+                $scheduledReportEvent = false;
+            }
         }
 
         // Add the report schedule if it doesn't exist and is enabled.
@@ -73,7 +74,10 @@ class Schedule
 
             if (isset($schedulesInterval[$timeReports], $schedulesInterval[$timeReports]['next_schedule'])) {
                 $scheduleTime = $schedulesInterval[$timeReports]['next_schedule'];
-                wp_schedule_event($scheduleTime, $timeReports, 'wp_statistics_report_hook');
+
+                if (wp_schedule_event($scheduleTime, $timeReports, 'wp_statistics_report_hook')) {
+                    $scheduledReportEvent = true;
+                }
             }
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: veronalabs, mostafa.s1990, kashani, GregRoss
 Donate link: https://wp-statistics.com/donate/
 Tags: analytics, google analytics, insights, stats, site visitors
 Requires at least: 6.6
-Tested up to: 7.0
+Tested up to: 7.1
 Stable tag: 14.16.10
 Requires PHP: 7.4
 License: GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wp-statistics.com/donate/
 Tags: analytics, google analytics, insights, stats, site visitors
 Requires at least: 6.6
 Tested up to: 7.1
-Stable tag: 14.16.10
+Stable tag: 14.16.11
 Requires PHP: 7.4
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -35,6 +35,7 @@ You can find more information in "[What we collect](https://wp-statistics.com/re
 * Fully integrate with your WordPress and your content structure and you have the all reports all in your WP dashboard
 * Content and Category Analytics: Track performance based on your site’s content and categories.
 * Simple analytics dashboard
+* Bounce Rate Tracking: See your site-wide bounce rate in Visitor Insights and per-page bounce rate in the Entry Pages report, so you can spot pages that lose visitors after a single page view.
 * Super easy to install. No coding or technical knowledge needed
 * Advanced data privacy settings that are customizable to fit your needs, in compliance with diverse data protection laws
 * Track URL parameters, including UTMs, for campaign analysis
@@ -110,6 +111,9 @@ Yes, you can run them both at the same time without any problems.
 = Are bot visits counted? =
 We filter out bot visits using best practice techniques. Compared to Google Analytics, your views and visitors are very similar. The "[Enhancing Data Accuracy](https://wp-statistics.com/resources/enhancing-data-accuracy/?utm_source=wporg&utm_medium=link&utm_campaign=doc)" article can help you eliminate bots even further.
 
+= Does WP Statistics show bounce rate? =
+Yes. WP Statistics reports your site-wide bounce rate in Visitor Insights and a bounce rate for each entry page. Bounce rate is the share of visits that viewed only one page, where a visit is one visitor on one day. No Google Analytics account is needed.
+
 = Can I export data? =
 Data can be exported to XML, CSV, or TSV files for backup or reporting purposes.
 
@@ -146,10 +150,13 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
-= 14.16.11 - Unreleased =
-- **Fix:** Email report schedules now update when the configured report frequency changes.
-- **New:** Added a site-wide Bounce Rate to the Visitor Insights overview and a Bounce Rate column to the entry pages reports. Bounce rate is the share of visits that viewed only one page, where a visit is one visitor on one day.
-- **Enhancement:** Bounce rate is now counted from the stored per-visit page count instead of scanning the visitor-page relationships table, so the reports load faster and cache correctly. Existing per-content bounce rates may shift slightly.
+= 14.16.11 - 2026-08-22 =
+- **New:** Bounce Rate in Visitor Insights and a Bounce Rate column in the Entry Pages report.
+- **Enhancement:** Faster bounce rate calculation. Existing per-content bounce rates may shift slightly.
+- **Enhancement:** New `wp_statistics_online_visitors_timeframe` filter to set how long a visitor counts as online.
+- **Enhancement:** Lighter admin dashboard for users without statistics access.
+- **Fix:** Email report schedules now update when the report frequency changes.
+- **Enhancement:** Tested up to WordPress 7.1.
 
 = 14.16.10 - 2026-07-25 =
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/readme.txt
+++ b/readme.txt
@@ -146,9 +146,11 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.11 - Unreleased =
+- **Fix:** Email report schedules now update when the configured report frequency changes.
+
 = 14.16.10 - 2026-07-25 =
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
-- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 = 14.16.9 - 2026-07-21 =

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ Yes, you can run them both at the same time without any problems.
 We filter out bot visits using best practice techniques. Compared to Google Analytics, your views and visitors are very similar. The "[Enhancing Data Accuracy](https://wp-statistics.com/resources/enhancing-data-accuracy/?utm_source=wporg&utm_medium=link&utm_campaign=doc)" article can help you eliminate bots even further.
 
 = Does WP Statistics show bounce rate? =
-Yes. WP Statistics reports your site-wide bounce rate in Visitor Insights and a bounce rate for each entry page. Bounce rate is the share of visits that viewed only one page, where a visit is one visitor on one day. No Google Analytics account is needed.
+Yes. WP Statistics reports your site-wide bounce rate in Visitor Insights and a bounce rate for each entry page. Bounce rate is the share of visits that recorded a single page view, where a visit is one visitor on one day. No Google Analytics account is needed.
 
 = Can I export data? =
 Data can be exported to XML, CSV, or TSV files for backup or reporting purposes.

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,8 @@ Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest versio
 == Changelog ==
 = 14.16.11 - Unreleased =
 - **Fix:** Email report schedules now update when the configured report frequency changes.
+- **New:** Added a site-wide Bounce Rate to the Visitor Insights overview and a Bounce Rate column to the entry pages reports. Bounce rate is the share of visits that viewed only one page, where a visit is one visitor on one day.
+- **Enhancement:** Bounce rate is now counted from the stored per-visit page count instead of scanning the visitor-page relationships table, so the reports load faster and cache correctly. Existing per-content bounce rates may shift slightly.
 
 = 14.16.10 - 2026-07-25 =
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,7 @@ Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest versio
 == Changelog ==
 = 14.16.10 - 2026-07-25 =
 - **Fix:** Prevented a fatal error on the tracking request when the referrer parameter was sent as an array instead of a single value.
+- **Fix:** Email report schedules now update when the configured report frequency changes.
 - **Enhancement:** General security hardening and internal improvements.
 
 = 14.16.9 - 2026-07-21 =

--- a/src/Models/OnlineModel.php
+++ b/src/Models/OnlineModel.php
@@ -34,8 +34,27 @@ class OnlineModel extends BaseModel
             'timeframe' => 5
         ]);
 
+        /**
+         * How many minutes a visitor counts as "online" for.
+         *
+         * The window was fixed at 5 minutes, so sites that wanted a different value had to
+         * edit the plugin on every update. This filter lets it be set once, from a small
+         * snippet, and it holds through updates. A whole-number of minutes is expected.
+         *
+         * @param int $minutes The online window in minutes.
+         *
+         * @example add_filter('wp_statistics_online_visitors_timeframe', function () { return 240; });
+         */
+        $minutes = (int) apply_filters('wp_statistics_online_visitors_timeframe', (int) $args['timeframe']);
+
+        // Guard against a snippet returning zero or a negative, which would make the window
+        // empty and always report nobody online.
+        if ($minutes < 1) {
+            $minutes = 5;
+        }
+
         $this->timeframe = [
-            'from' => DateTime::get('-' . $args['timeframe'] . ' min', 'Y-m-d H:i:s'),
+            'from' => DateTime::get('-' . $minutes . ' min', 'Y-m-d H:i:s'),
             'to'   => DateTime::get('now', 'Y-m-d H:i:s')
         ];
     }

--- a/src/Models/OnlineModel.php
+++ b/src/Models/OnlineModel.php
@@ -31,30 +31,20 @@ class OnlineModel extends BaseModel
     public function setArgs($args = [])
     {
         $args = wp_parse_args($args, [
-            'timeframe' => 5
+            /**
+             * How many minutes a visitor counts as "online" for.
+             *
+             * The window was fixed at 5 minutes, so sites that wanted a different value had
+             * to edit the plugin on every update. This filter lets it be set once, from a
+             * small snippet, and it holds through updates.
+             *
+             * @example add_filter('wp_statistics_online_visitors_timeframe', function () { return 240; });
+             */
+            'timeframe' => apply_filters('wp_statistics_online_visitors_timeframe', 5)
         ]);
 
-        /**
-         * How many minutes a visitor counts as "online" for.
-         *
-         * The window was fixed at 5 minutes, so sites that wanted a different value had to
-         * edit the plugin on every update. This filter lets it be set once, from a small
-         * snippet, and it holds through updates. A whole-number of minutes is expected.
-         *
-         * @param int $minutes The online window in minutes.
-         *
-         * @example add_filter('wp_statistics_online_visitors_timeframe', function () { return 240; });
-         */
-        $minutes = (int) apply_filters('wp_statistics_online_visitors_timeframe', (int) $args['timeframe']);
-
-        // Guard against a snippet returning zero or a negative, which would make the window
-        // empty and always report nobody online.
-        if ($minutes < 1) {
-            $minutes = 5;
-        }
-
         $this->timeframe = [
-            'from' => DateTime::get('-' . $minutes . ' min', 'Y-m-d H:i:s'),
+            'from' => DateTime::get('-' . $args['timeframe'] . ' min', 'Y-m-d H:i:s'),
             'to'   => DateTime::get('now', 'Y-m-d H:i:s')
         ];
     }

--- a/src/Models/VisitorsModel.php
+++ b/src/Models/VisitorsModel.php
@@ -1490,6 +1490,20 @@ class VisitorsModel extends BaseModel
         return intval($result);
     }
 
+    /**
+     * Returns the bounce rate as a percentage.
+     *
+     * A bounce is a visit that viewed only one page. WP Statistics stores one visitor row per
+     * IP/browser per calendar day, so a "visit" here means one visitor on one day, not a
+     * 30-minute session. Reloading the same page counts as a second view, so a reload is not
+     * a bounce.
+     *
+     * When a resource is passed, the rate is scoped to the visits that landed on that resource
+     * (the landing page bounce rate). Without a resource it returns the site-wide bounce rate.
+     *
+     * @param array $args
+     * @return float
+     */
     public function getBounceRate($args = [])
     {
         $args = $this->parseArgs($args, [
@@ -1499,27 +1513,58 @@ class VisitorsModel extends BaseModel
             'query_param'   => ''
         ]);
 
-        $singlePageVisitors = Query::select('visitor_id')
-            ->from('visitor_relationships')
-            ->whereDate('date', $args['date'])
-            ->groupBy('visitor_id')
-            ->having('COUNT(page_id) = 1')
-            ->getQuery();
+        $bounceVisitors = $this->countBounceVisitors($args);
 
-        $query = Query::select(['COUNT(visitor.ID) as visitors'])
-            ->fromQuery($singlePageVisitors, 'single')
-            ->join('visitor', ['visitor.ID', 'single.visitor_id'])
-            ->join('pages', ['visitor.first_page', 'pages.page_id'])
-            ->where('pages.id', '=', $args['resource_id'])
-            ->where('pages.type', 'IN', $args['resource_type'])
-            ->where('pages.uri', '=', $args['query_param']);
+        $totalVisitors = $this->isResourceScoped($args)
+            ? $this->countEntryPageVisitors($args)
+            : $this->countVisitors(['date' => $args['date']]);
 
-        $singlePageVisits = $query->getVar() ?? 0;
-        $totalPageEntries = $this->countEntryPageVisitors($args);
+        return Helper::calculatePercentage($bounceVisitors, $totalVisitors);
+    }
 
-        $result = Helper::calculatePercentage($singlePageVisits, $totalPageEntries);
+    /**
+     * Counts the visits that viewed a single page.
+     *
+     * `visitor.hits` is incremented on every recorded hit, so `hits = 1` is the number of
+     * single-page visits without touching any other table.
+     *
+     * @param array $args
+     * @return int
+     */
+    public function countBounceVisitors($args = [])
+    {
+        $args = $this->parseArgs($args, [
+            'date'          => '',
+            'resource_id'   => '',
+            'resource_type' => '',
+            'query_param'   => ''
+        ]);
 
-        return $result;
+        $query = Query::select(['COUNT(DISTINCT visitor.ID) as visitors'])
+            ->from('visitor')
+            ->where('visitor.hits', '=', 1)
+            ->whereDate('visitor.last_counter', $args['date']);
+
+        if ($this->isResourceScoped($args)) {
+            $query
+                ->join('pages', ['visitor.first_page', 'pages.page_id'])
+                ->where('pages.id', '=', $args['resource_id'])
+                ->where('pages.type', 'IN', $args['resource_type'])
+                ->where('pages.uri', '=', $args['query_param']);
+        }
+
+        return intval($query->getVar());
+    }
+
+    /**
+     * Whether the given arguments limit the query to a specific resource.
+     *
+     * @param array $args
+     * @return bool
+     */
+    private function isResourceScoped($args)
+    {
+        return !empty($args['resource_id']) || !empty($args['resource_type']) || !empty($args['query_param']);
     }
 
     public function countEntryPageVisitors($args = [])
@@ -1584,6 +1629,7 @@ class VisitorsModel extends BaseModel
 
         $query = Query::select([
             'COUNT(visitor.ID) as visitors',
+            'COALESCE(SUM(CASE WHEN visitor.hits = 1 THEN 1 ELSE 0 END) / COUNT(visitor.ID), 0) * 100 as bounce_rate',
             'pages.id as post_id',
             'pages.page_id',
             'posts.post_title',

--- a/src/Service/Admin/Metabox/MetaboxManager.php
+++ b/src/Service/Admin/Metabox/MetaboxManager.php
@@ -6,6 +6,7 @@ if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
 use WP_Screen;
 use WP_Statistics\Core\CoreFactory;
+use WP_STATISTICS\User;
 
 class MetaboxManager
 {
@@ -22,6 +23,10 @@ class MetaboxManager
      */
     public function registerMetaboxes()
     {
+        if (!User::Access('read')) {
+            return;
+        }
+
         $metaboxes = MetaboxHelper::getActiveMetaboxes();
 
         foreach ($metaboxes as $metabox) {
@@ -39,6 +44,10 @@ class MetaboxManager
      */
     public function hideDashboardMetaboxes()
     {
+        if (!User::Access('read')) {
+            return;
+        }
+
         $userId             = get_current_user_id();
         $hiddenMetaboxesKey = 'metaboxhidden_dashboard';
         $metaboxInitFlagKey = 'wp_statistics_metaboxhidden_dashboard_initialized';

--- a/src/Service/Admin/SiteHealthInfo.php
+++ b/src/Service/Admin/SiteHealthInfo.php
@@ -145,7 +145,7 @@ class SiteHealthInfo
             'geoIpDatabaseValidation'        => [
                 'label' => esc_html__('GeoIP Database Validation', 'wp-statistics'),
                 'value' => is_wp_error($geoIpProviderValidity) ? esc_html__('No', 'wp-statistics') : esc_html__('Yes', 'wp-statistics'),
-                'debug' => is_wp_error($geoIpProviderValidity) ? $geoIpProviderValidity->get_error_code() : 'Yes',
+                'debug' => is_wp_error($geoIpProviderValidity) ? $geoIpProviderValidity->get_error_message() : 'Yes',
             ],
 
             /**

--- a/src/Service/Admin/VisitorInsights/VisitorInsightsDataProvider.php
+++ b/src/Service/Admin/VisitorInsights/VisitorInsightsDataProvider.php
@@ -51,6 +51,9 @@ class VisitorInsightsDataProvider
         $loggedInShare      = Helper::calculatePercentage($loggedIn, $visitors);
         $prevLoggedInShare  = Helper::calculatePercentage($prevLoggedIn, $prevVisitors);
 
+        $bounceRate     = $this->visitorsModel->getBounceRate();
+        $prevBounceRate = $this->visitorsModel->getBounceRate(['date' => DateRange::getPrevPeriod()]);
+
         $referrers      = $this->visitorsModel->getReferrers(['decorate' => true, 'per_page' => 5]);
         $topVisitors    = $this->visitorsModel->getVisitorsData(['order_by' => 'hits', 'order' => 'DESC', 'page' => 1, 'per_page' => 5]);
         $entryPages     = $this->visitorsModel->getEntryPages(['per_page' => 5]);
@@ -63,6 +66,11 @@ class VisitorInsightsDataProvider
             'views'     => [
                 'value'     => $views,
                 'change'    => Helper::calculatePercentageChange($prevViews, $views)
+            ],
+            'bounce_rate' => [
+                'value'     => $bounceRate . '%',
+                // Percentage metrics report an absolute point difference, not a relative change.
+                'change'    => ($prevVisitors == 0) ? null : round($bounceRate - $prevBounceRate, 1)
             ],
             'country'   => $overviewChartData['countries']['labels'][0] ?? '',
             'referrer'  => isset($referrers[0]) ? $referrers[0]->getRawReferrer() : '',

--- a/src/Service/Geolocation/AbstractGeoIPProvider.php
+++ b/src/Service/Geolocation/AbstractGeoIPProvider.php
@@ -135,10 +135,10 @@ abstract class AbstractGeoIPProvider implements GeoServiceProviderInterface
     public function getRelativeDatabasePath()
     {
         $databasePath = wp_normalize_path($this->getDatabasePath());
-        $rootPath     = wp_normalize_path(ABSPATH);
+        $rootPath     = trailingslashit(wp_normalize_path(ABSPATH));
 
         if (strpos($databasePath, $rootPath) === 0) {
-            return ltrim(substr($databasePath, strlen($rootPath)), '/');
+            return substr($databasePath, strlen($rootPath));
         }
 
         return wp_basename($databasePath);

--- a/src/Service/Geolocation/AbstractGeoIPProvider.php
+++ b/src/Service/Geolocation/AbstractGeoIPProvider.php
@@ -125,6 +125,26 @@ abstract class AbstractGeoIPProvider implements GeoServiceProviderInterface
     }
 
     /**
+     * Get the database path relative to the WordPress root.
+     *
+     * Error messages are surfaced in Site Health, which site owners routinely paste into
+     * public support threads, so the absolute server path is trimmed off.
+     *
+     * @return string
+     */
+    public function getRelativeDatabasePath()
+    {
+        $databasePath = wp_normalize_path($this->getDatabasePath());
+        $rootPath     = wp_normalize_path(ABSPATH);
+
+        if (strpos($databasePath, $rootPath) === 0) {
+            return ltrim(substr($databasePath, strlen($rootPath)), '/');
+        }
+
+        return wp_basename($databasePath);
+    }
+
+    /**
      * Get the last updated timestamp for the Geolocation database file.
      *
      * @return false|string

--- a/src/Service/Geolocation/GeoServiceProviderInterface.php
+++ b/src/Service/Geolocation/GeoServiceProviderInterface.php
@@ -2,6 +2,8 @@
 
 namespace WP_Statistics\Service\Geolocation;
 
+use WP_Error;
+
 interface GeoServiceProviderInterface
 {
     /**
@@ -22,7 +24,7 @@ interface GeoServiceProviderInterface
     /**
      * Download the GeoIP database, extract it, and handle updates.
      *
-     * @return array
+     * @return bool|WP_Error True on success, or WP_Error on failure.
      */
     public function downloadDatabase();
 

--- a/src/Service/Geolocation/Provider/CloudflareGeolocationProvider.php
+++ b/src/Service/Geolocation/Provider/CloudflareGeolocationProvider.php
@@ -6,6 +6,7 @@ use WP_STATISTICS\Country;
 use WP_STATISTICS\IP;
 use WP_Statistics\Service\Geolocation\AbstractGeoIPProvider;
 use Exception;
+use WP_Error;
 
 class CloudflareGeolocationProvider extends AbstractGeoIPProvider
 {
@@ -140,9 +141,14 @@ class CloudflareGeolocationProvider extends AbstractGeoIPProvider
         return '';
     }
 
+    /**
+     * Cloudflare does not require a local database download.
+     *
+     * @return bool|WP_Error True on success, or WP_Error on failure.
+     */
     public function downloadDatabase()
     {
-        return [];
+        return true;
     }
 
     public function getDatabaseType()

--- a/src/Service/Geolocation/Provider/DbIpProvider.php
+++ b/src/Service/Geolocation/Provider/DbIpProvider.php
@@ -120,6 +120,11 @@ class DbIpProvider extends AbstractGeoIPProvider
         return $this->getFilteredDownloadUrl($defaultUrl);
     }
 
+    /**
+     * Download the GeoIP database, extract it, and handle updates.
+     *
+     * @return bool|WP_Error True on success, or WP_Error on failure.
+     */
     public function downloadDatabase()
     {
         $gzFilePath = $this->getFilePath('dbip-city-lite.mmdb.gz');

--- a/src/Service/Geolocation/Provider/DbIpProvider.php
+++ b/src/Service/Geolocation/Provider/DbIpProvider.php
@@ -238,7 +238,7 @@ class DbIpProvider extends AbstractGeoIPProvider
             if (empty($this->reader) || !method_exists($this->reader, 'metadata')) {
                 throw new Exception(
                     /* translators: %s: string value */
-                    sprintf(__('Failed to initialize GeoIP reader or invalid database file. Please remove the existing database file at %s and let the plugin redownload it.', 'wp-statistics'), $this->getDatabasePath())
+                    sprintf(__('Failed to initialize GeoIP reader or invalid database file. Please remove the existing database file at %s and let the plugin redownload it.', 'wp-statistics'), $this->getRelativeDatabasePath())
                 );
             }
 

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -105,6 +105,28 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
     }
 
     /**
+     * Close the GeoIP Reader and release its file handle.
+     *
+     * @return void
+     */
+    protected function closeReader()
+    {
+        if (empty($this->reader)) {
+            return;
+        }
+
+        try {
+            if (method_exists($this->reader, 'close')) {
+                $this->reader->close();
+            }
+        } catch (Exception $e) {
+            WP_Statistics::log('Failed to close GeoIP reader: ' . $e->getMessage());
+        }
+
+        $this->reader = null;
+    }
+
+    /**
      * Get the download URL for the Maxmind GeoIP database.
      *
      * @return string
@@ -158,6 +180,10 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
             $this->extractGzFile($gzFilePath, $tempDbFile);
             $this->validateDownloadedDatabaseFile($tempDbFile);
 
+            // Windows refuses to rename over a file that is still open, so release the
+            // active reader's handle before swapping the new database in.
+            $this->closeReader();
+
             if (!rename($tempDbFile, $dbFile)) {
                 throw new Exception(esc_html__('Failed to replace the existing GeoIP database. The existing database was left unchanged.', 'wp-statistics'));
             }
@@ -179,6 +205,12 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
         } catch (Exception $e) {
             $this->deleteFile($gzFilePath); // Ensure temporary file is deleted in case of an error
             $this->deleteFile($tempDbFile);
+
+            // The reader may have been closed before a failed swap. Reopen it against the
+            // database that is still in place, without re-entering the download path.
+            if (empty($this->reader) && $this->isDatabaseExist()) {
+                $this->initializeReader();
+            }
 
             WP_Statistics::log($e->getMessage()); // Log the error for debugging
 
@@ -317,7 +349,7 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
             if (empty($this->reader) || !method_exists($this->reader, 'metadata')) {
                 throw new Exception(
                     /* translators: %s: string value */
-                    sprintf(__('Failed to initialize GeoIP reader or invalid database file. Please remove the existing database file at %s and let the plugin redownload it.', 'wp-statistics'), $this->getDatabasePath())
+                    sprintf(__('Failed to initialize GeoIP reader or invalid database file. Please remove the existing database file at %s and let the plugin redownload it.', 'wp-statistics'), $this->getRelativeDatabasePath())
                 );
             }
 

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -144,15 +144,15 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
             ]);
 
             if (is_wp_error($response)) {
-                /* translators: %1$s: string value, %2$s: string value */
-                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database from: %1$s - %2$s', 'wp-statistics'), $downloadUrl, $response->get_error_message()));
+                /* translators: %s: transport error message */
+                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database: %s', 'wp-statistics'), $response->get_error_message()));
             }
 
             // Check the HTTP status code
             $statusCode = wp_remote_retrieve_response_code($response);
             if ($statusCode !== 200) {
-                /* translators: %1$d: number value, %2$s: string value */
-                throw new Exception(sprintf(esc_html__('Unexpected HTTP status code %1$d while downloading GeoIP database from: %2$s', 'wp-statistics'), $statusCode, $downloadUrl));
+                /* translators: %d: HTTP status code */
+                throw new Exception(sprintf(esc_html__('Unexpected HTTP status code %d while downloading GeoIP database.', 'wp-statistics'), $statusCode));
             }
 
             $this->extractGzFile($gzFilePath, $tempDbFile);

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -125,19 +125,28 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
     /**
      * Download the GeoIP database, extract it, and handle updates.
      *
-     * @return array
+     * @return bool|WP_Error
      */
     public function downloadDatabase()
     {
         $gzFilePath = $this->getFilePath('GeoLite2-City.mmdb.gz');
+        $dbFile     = $this->getDatabasePath();
+        $tempDbFile = $dbFile . '.tmp';
 
         try {
+            $this->deleteFile($tempDbFile);
+
             $downloadUrl = $this->getDownloadUrl();
             $response    = wp_remote_get($downloadUrl, [
                 'stream'   => true,
                 'filename' => $gzFilePath,
                 'timeout'  => 120,
             ]);
+
+            if (is_wp_error($response)) {
+                /* translators: %1$s: string value, %2$s: string value */
+                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database from: %1$s - %2$s', 'wp-statistics'), $downloadUrl, $response->get_error_message()));
+            }
 
             // Check the HTTP status code
             $statusCode = wp_remote_retrieve_response_code($response);
@@ -146,15 +155,15 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
                 throw new Exception(sprintf(esc_html__('Unexpected HTTP status code %1$d while downloading GeoIP database from: %2$s', 'wp-statistics'), $statusCode, $downloadUrl));
             }
 
-            if (is_wp_error($response)) {
-                /* translators: %1$s: string value, %2$s: string value */
-                throw new Exception(sprintf(esc_html__('Error downloading GeoIP database from: %1$s - %2$s', 'wp-statistics'), $downloadUrl, $response->get_error_message()));
+            $this->extractGzFile($gzFilePath, $tempDbFile);
+            $this->validateDownloadedDatabaseFile($tempDbFile);
+
+            if (!rename($tempDbFile, $dbFile)) {
+                throw new Exception(esc_html__('Failed to replace the existing GeoIP database. The existing database was left unchanged.', 'wp-statistics'));
             }
 
-            $dbFile = $this->getDatabasePath();
-
-            $this->extractGzFile($gzFilePath, $dbFile); // Extract the downloaded file
             $this->deleteFile($gzFilePath); // Clean up the temporary file
+            $this->reader = new Reader($dbFile);
 
             // Update options and send notifications
             $this->updateLastDownloadTimestamp();
@@ -169,6 +178,7 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
 
         } catch (Exception $e) {
             $this->deleteFile($gzFilePath); // Ensure temporary file is deleted in case of an error
+            $this->deleteFile($tempDbFile);
 
             WP_Statistics::log($e->getMessage()); // Log the error for debugging
 
@@ -176,6 +186,32 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
         }
 
         return true;
+    }
+
+    /**
+     * Validate a downloaded database before replacing the active database.
+     *
+     * @param string $databasePath
+     * @return void
+     * @throws Exception
+     */
+    protected function validateDownloadedDatabaseFile(string $databasePath)
+    {
+        try {
+            $reader       = new Reader($databasePath);
+            $databaseType = $reader->metadata()->databaseType;
+
+            if ($databaseType !== 'GeoLite2-City') {
+                /* translators: %s: string value */
+                throw new Exception(sprintf(esc_html__('Unexpected database type %s', 'wp-statistics'), $databaseType));
+            }
+        } catch (Exception $e) {
+            throw new Exception(sprintf(
+                /* translators: %s: validation error message */
+                esc_html__('The downloaded MaxMind GeoIP database is invalid: %s The existing database was left unchanged. Please delete the MaxMind database and retry the update, or switch to DB-IP and download its database.', 'wp-statistics'),
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
+++ b/src/Service/Geolocation/Provider/MaxmindGeoIPProvider.php
@@ -105,28 +105,6 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
     }
 
     /**
-     * Close the GeoIP Reader and release its file handle.
-     *
-     * @return void
-     */
-    protected function closeReader()
-    {
-        if (empty($this->reader)) {
-            return;
-        }
-
-        try {
-            if (method_exists($this->reader, 'close')) {
-                $this->reader->close();
-            }
-        } catch (Exception $e) {
-            WP_Statistics::log('Failed to close GeoIP reader: ' . $e->getMessage());
-        }
-
-        $this->reader = null;
-    }
-
-    /**
      * Get the download URL for the Maxmind GeoIP database.
      *
      * @return string
@@ -180,10 +158,6 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
             $this->extractGzFile($gzFilePath, $tempDbFile);
             $this->validateDownloadedDatabaseFile($tempDbFile);
 
-            // Windows refuses to rename over a file that is still open, so release the
-            // active reader's handle before swapping the new database in.
-            $this->closeReader();
-
             if (!rename($tempDbFile, $dbFile)) {
                 throw new Exception(esc_html__('Failed to replace the existing GeoIP database. The existing database was left unchanged.', 'wp-statistics'));
             }
@@ -205,12 +179,6 @@ class MaxmindGeoIPProvider extends AbstractGeoIPProvider
         } catch (Exception $e) {
             $this->deleteFile($gzFilePath); // Ensure temporary file is deleted in case of an error
             $this->deleteFile($tempDbFile);
-
-            // The reader may have been closed before a failed swap. Reopen it against the
-            // database that is still in place, without re-entering the download path.
-            if (empty($this->reader) && $this->isDatabaseExist()) {
-                $this->initializeReader();
-            }
 
             WP_Statistics::log($e->getMessage()); // Log the error for debugging
 

--- a/tests/integration/Test_MaxmindGeoIPProvider.php
+++ b/tests/integration/Test_MaxmindGeoIPProvider.php
@@ -69,6 +69,36 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertStringContainsString('switch to DB-IP', $result->get_error_message());
         $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
         $this->assertFileDoesNotExist($this->databasePath . '.tmp');
+        $this->assertFileDoesNotExist(dirname($this->databasePath) . '/GeoLite2-City.mmdb.gz');
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
+    }
+
+    public function test_malformed_archive_keeps_existing_database_and_cleans_up_files()
+    {
+        Option::update('geoip_license_type', 'user-license');
+        Option::update('geoip_license_key', 'test-license-key');
+
+        add_filter('pre_http_request', function ($response, $args) {
+            file_put_contents($args['filename'], "\x1f\x8b\x08");
+
+            return [
+                'headers'  => [],
+                'body'     => '',
+                'response' => [
+                    'code'    => 200,
+                    'message' => 'OK',
+                ],
+                'cookies'  => [],
+            ];
+        }, 10, 2);
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('Failed to extract the database file', $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertFileDoesNotExist($this->databasePath . '.tmp');
+        $this->assertFileDoesNotExist(dirname($this->databasePath) . '/GeoLite2-City.mmdb.gz');
         $this->assertSame(12345, Option::get('last_geoip_dl'));
     }
 
@@ -88,6 +118,8 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertWPError($result);
         $this->assertStringContainsString('Connection failed.', $result->get_error_message());
         $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
 
         remove_all_filters('pre_http_request');
         add_filter('pre_http_request', function () {
@@ -107,6 +139,8 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertWPError($result);
         $this->assertStringContainsString('HTTP status code 403', $result->get_error_message());
         $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
     }
 
     public function test_cloudflare_download_is_a_successful_no_op()

--- a/tests/integration/Test_MaxmindGeoIPProvider.php
+++ b/tests/integration/Test_MaxmindGeoIPProvider.php
@@ -4,6 +4,8 @@ namespace WP_Statistics\Tests\Service\Geolocation\Provider;
 
 if (!defined('ABSPATH')) exit; // Exit if accessed directly
 
+use WP_Error;
+use WP_Statistics\Service\Geolocation\Provider\CloudflareGeolocationProvider;
 use WP_Statistics\Service\Geolocation\Provider\MaxmindGeoIPProvider;
 use WP_STATISTICS\Option;
 use WP_UnitTestCase;
@@ -68,5 +70,49 @@ class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
         $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
         $this->assertFileDoesNotExist($this->databasePath . '.tmp');
         $this->assertSame(12345, Option::get('last_geoip_dl'));
+    }
+
+    public function test_download_error_does_not_expose_maxmind_license_key()
+    {
+        $licenseKey = 'secret-license-key';
+
+        Option::update('geoip_license_type', 'user-license');
+        Option::update('geoip_license_key', $licenseKey);
+
+        add_filter('pre_http_request', function () {
+            return new WP_Error('http_request_failed', 'Connection failed.');
+        });
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('Connection failed.', $result->get_error_message());
+        $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+
+        remove_all_filters('pre_http_request');
+        add_filter('pre_http_request', function () {
+            return [
+                'headers'  => [],
+                'body'     => '',
+                'response' => [
+                    'code'    => 403,
+                    'message' => 'Forbidden',
+                ],
+                'cookies'  => [],
+            ];
+        });
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('HTTP status code 403', $result->get_error_message());
+        $this->assertStringNotContainsString($licenseKey, $result->get_error_message());
+    }
+
+    public function test_cloudflare_download_is_a_successful_no_op()
+    {
+        $provider = new CloudflareGeolocationProvider();
+
+        $this->assertTrue($provider->downloadDatabase());
     }
 }

--- a/tests/integration/Test_MaxmindGeoIPProvider.php
+++ b/tests/integration/Test_MaxmindGeoIPProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace WP_Statistics\Tests\Service\Geolocation\Provider;
+
+if (!defined('ABSPATH')) exit; // Exit if accessed directly
+
+use WP_Statistics\Service\Geolocation\Provider\MaxmindGeoIPProvider;
+use WP_STATISTICS\Option;
+use WP_UnitTestCase;
+
+class Test_MaxmindGeoIPProvider extends WP_UnitTestCase
+{
+    private $provider;
+    private $databasePath;
+    private $originalDatabase = 'existing-invalid-database';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Option::update('geoip_location_detection_method', 'maxmind');
+        Option::update('geoip_license_type', 'js-deliver');
+        Option::update('last_geoip_dl', 12345);
+
+        $uploadDir          = wp_upload_dir();
+        $this->databasePath = $uploadDir['basedir'] . '/' . WP_STATISTICS_UPLOADS_DIR . '/GeoLite2-City.mmdb';
+
+        wp_mkdir_p(dirname($this->databasePath));
+        file_put_contents($this->databasePath, $this->originalDatabase);
+
+        $this->provider = new MaxmindGeoIPProvider();
+    }
+
+    public function tearDown(): void
+    {
+        remove_all_filters('pre_http_request');
+        wp_delete_file($this->databasePath);
+        wp_delete_file($this->databasePath . '.tmp');
+        wp_delete_file($this->databasePath . '.backup');
+        wp_delete_file(dirname($this->databasePath) . '/GeoLite2-City.mmdb.gz');
+
+        parent::tearDown();
+    }
+
+    public function test_corrupt_download_keeps_existing_database_and_returns_recovery_steps()
+    {
+        add_filter('pre_http_request', function ($response, $args) {
+            file_put_contents($args['filename'], gzencode('not-a-valid-mmdb'));
+
+            return [
+                'headers'  => [],
+                'body'     => '',
+                'response' => [
+                    'code'    => 200,
+                    'message' => 'OK',
+                ],
+                'cookies'  => [],
+            ];
+        }, 10, 2);
+
+        $result = $this->provider->downloadDatabase();
+
+        $this->assertWPError($result);
+        $this->assertStringContainsString('downloaded MaxMind GeoIP database is invalid', $result->get_error_message());
+        $this->assertStringContainsString('existing database was left unchanged', $result->get_error_message());
+        $this->assertStringContainsString('delete the MaxMind database and retry', $result->get_error_message());
+        $this->assertStringContainsString('switch to DB-IP', $result->get_error_message());
+        $this->assertSame($this->originalDatabase, file_get_contents($this->databasePath));
+        $this->assertFileDoesNotExist($this->databasePath . '.tmp');
+        $this->assertSame(12345, Option::get('last_geoip_dl'));
+    }
+}

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -47,6 +47,7 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
         }
 
         remove_role('wps_manager_only');
+        remove_role('wps_reader_only');
         wp_set_current_user(0);
         set_current_screen('front');
 
@@ -93,7 +94,24 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
     public function test_authorized_readers_receive_admin_assets()
     {
-        $this->setCurrentUserWithRole('administrator');
+        add_role(
+            'wps_reader_only',
+            'WP Statistics Reader',
+            [
+                'read'           => true,
+                'wps_read_stats' => true,
+            ]
+        );
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        $this->setCurrentUserWithRole('wps_reader_only');
+
+        $this->assertTrue(User::Access('read'));
+        $this->assertFalse(User::Access('manage'));
 
         $this->assets->admin_styles();
         $this->assets->admin_scripts('index.php');

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -131,6 +131,7 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
         $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertSame(0, $this->metaboxListCalls);
     }
 
     private function setCurrentUserWithRole(string $role): void

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -1,0 +1,147 @@
+<?php
+
+use WP_Statistics\Service\Admin\Metabox\MetaboxManager;
+use WP_STATISTICS\Admin_Assets;
+use WP_STATISTICS\Option;
+use WP_STATISTICS\User;
+
+class Test_AdminAccessGuards extends WP_UnitTestCase
+{
+    private $assets;
+    private $metaboxManager;
+    private $metaboxListCalls = 0;
+    private $originalOptions;
+    private $hadOriginalOptions;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (!class_exists(Admin_Assets::class)) {
+            require_once WP_STATISTICS_DIR . 'includes/admin/class-wp-statistics-admin-assets.php';
+        }
+
+        $this->originalOptions    = get_option(Option::$opt_name);
+        $this->hadOriginalOptions = false !== $this->originalOptions;
+        $this->assets             = new Admin_Assets();
+        $this->metaboxManager     = new MetaboxManager();
+
+        add_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
+        set_current_screen('dashboard');
+        $this->resetAssetQueues();
+    }
+
+    public function tearDown(): void
+    {
+        remove_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
+        remove_action('admin_init', [$this->metaboxManager, 'registerMetaboxes']);
+        remove_action('admin_init', [$this->metaboxManager, 'hideDashboardMetaboxes']);
+        remove_action('admin_enqueue_scripts', [$this->assets, 'admin_styles'], 999);
+        remove_action('admin_enqueue_scripts', [$this->assets, 'admin_scripts'], 999);
+        remove_filter('wp_statistics_enqueue_chartjs', [$this->assets, 'shouldEnqueueChartJs']);
+
+        if ($this->hadOriginalOptions) {
+            update_option(Option::$opt_name, $this->originalOptions);
+        } else {
+            delete_option(Option::$opt_name);
+        }
+
+        remove_role('wps_manager_only');
+        wp_set_current_user(0);
+        set_current_screen('front');
+
+        parent::tearDown();
+    }
+
+    public function recordMetaboxList(array $metaboxes): array
+    {
+        $this->metaboxListCalls++;
+
+        return [];
+    }
+
+    public function test_unauthorized_users_do_not_build_metaboxes()
+    {
+        $this->setCurrentUserWithRole('subscriber');
+
+        $this->metaboxManager->registerMetaboxes();
+        $this->metaboxManager->hideDashboardMetaboxes();
+
+        $this->assertSame(0, $this->metaboxListCalls);
+    }
+
+    public function test_authorized_readers_build_metaboxes()
+    {
+        $this->setCurrentUserWithRole('administrator');
+
+        $this->metaboxManager->registerMetaboxes();
+        $this->metaboxManager->hideDashboardMetaboxes();
+
+        $this->assertSame(2, $this->metaboxListCalls);
+    }
+
+    public function test_unauthorized_users_do_not_receive_admin_assets()
+    {
+        $this->setCurrentUserWithRole('subscriber');
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertFalse(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertFalse(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    public function test_authorized_readers_receive_admin_assets()
+    {
+        $this->setCurrentUserWithRole('administrator');
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    public function test_manage_only_users_keep_admin_assets_but_skip_metaboxes()
+    {
+        add_role(
+            'wps_manager_only',
+            'WP Statistics Manager',
+            [
+                'read'             => true,
+                'wps_manage_stats' => true,
+            ]
+        );
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        $this->setCurrentUserWithRole('wps_manager_only');
+
+        $this->assertTrue(User::Access('manage'));
+        $this->assertFalse(User::Access('read'));
+
+        $this->metaboxManager->registerMetaboxes();
+        $this->assertSame(0, $this->metaboxListCalls);
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    private function setCurrentUserWithRole(string $role): void
+    {
+        $userId = self::factory()->user->create(['role' => $role]);
+        wp_set_current_user($userId);
+    }
+
+    private function resetAssetQueues(): void
+    {
+        wp_styles()->queue  = [];
+        wp_scripts()->queue = [];
+    }
+}

--- a/tests/unit/Test_Schedule.php
+++ b/tests/unit/Test_Schedule.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace WP_Statistics\Tests;
+
+use WP_STATISTICS\Option;
+use WP_STATISTICS\Schedule;
+use WP_UnitTestCase;
+
+class Test_Schedule extends WP_UnitTestCase
+{
+    private const REPORT_HOOK = 'wp_statistics_report_hook';
+
+    public function tearDown(): void
+    {
+        wp_clear_scheduled_hook(self::REPORT_HOOK);
+        Option::update('time_report', '0');
+
+        parent::tearDown();
+    }
+
+    public function test_report_event_is_rescheduled_when_frequency_changes()
+    {
+        Option::update('time_report', 'weekly');
+        wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::REPORT_HOOK);
+
+        Schedule::get_instance()->maybe_schedule_hooks();
+
+        $this->assertSame('weekly', wp_get_schedule(self::REPORT_HOOK));
+    }
+}

--- a/tests/unit/Test_Schedule.php
+++ b/tests/unit/Test_Schedule.php
@@ -10,10 +10,31 @@ class Test_Schedule extends WP_UnitTestCase
 {
     private const REPORT_HOOK = 'wp_statistics_report_hook';
 
+    private const SCHEDULE_HOOKS = [
+        'wp_statistics_dbmaint_hook',
+        'wp_statistics_referrals_db_hook',
+        self::REPORT_HOOK,
+        'wp_statistics_licenses_hook',
+        'wp_statistics_geoip_hook',
+        'wp_statistics_check_licenses_status',
+    ];
+
+    private $originalTimeReport;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalTimeReport = Option::get('time_report');
+    }
+
     public function tearDown(): void
     {
-        wp_clear_scheduled_hook(self::REPORT_HOOK);
-        Option::update('time_report', '0');
+        foreach (self::SCHEDULE_HOOKS as $hook) {
+            wp_clear_scheduled_hook($hook);
+        }
+
+        Option::update('time_report', $this->originalTimeReport);
 
         parent::tearDown();
     }

--- a/tests/unit/Test_Schedule.php
+++ b/tests/unit/Test_Schedule.php
@@ -42,7 +42,10 @@ class Test_Schedule extends WP_UnitTestCase
     public function test_report_event_is_rescheduled_when_frequency_changes()
     {
         Option::update('time_report', 'weekly');
-        wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::REPORT_HOOK);
+        wp_clear_scheduled_hook(self::REPORT_HOOK);
+
+        $this->assertTrue(wp_schedule_event(time() + HOUR_IN_SECONDS, 'daily', self::REPORT_HOOK));
+        $this->assertSame('daily', wp_get_schedule(self::REPORT_HOOK));
 
         Schedule::get_instance()->maybe_schedule_hooks();
 

--- a/views/components/tables/top-entry-pages.php
+++ b/views/components/tables/top-entry-pages.php
@@ -22,6 +22,9 @@ use WP_Statistics\Components\View;
                         <span class="wps-order"><?php esc_html_e('Unique Entrances', 'wp-statistics') ?></span>
                     </th>
                     <th scope="col" class="wps-pd-l">
+                        <?php esc_html_e('Bounce Rate', 'wp-statistics') ?>
+                    </th>
+                    <th scope="col" class="wps-pd-l">
                         <?php esc_html_e('Publish Date', 'wp-statistics') ?>
                     </th>
                     <th scope="col">
@@ -44,6 +47,10 @@ use WP_Statistics\Components\View;
 
                         <td class="wps-pd-l">
                             <span><?php echo esc_html(number_format_i18n($page->visitors)); ?></span>
+                        </td>
+
+                        <td class="wps-pd-l">
+                            <span><?php echo esc_html(round((float) ($page->bounce_rate ?? 0), 1) . '%'); ?></span>
                         </td>
 
                         <td class="wps-pd-l">

--- a/views/components/tables/visitors-top-entry-pages.php
+++ b/views/components/tables/visitors-top-entry-pages.php
@@ -20,6 +20,9 @@ use WP_STATISTICS\Visitor;
                     <th class="wps-pd-l">
                         <?php esc_html_e('Unique Entrances', 'wp-statistics') ?>
                     </th>
+                    <th class="wps-pd-l">
+                        <?php esc_html_e('Bounce Rate', 'wp-statistics') ?>
+                    </th>
                     <th class="wps-pd-l"></th>
                 </tr>
                 </thead>
@@ -37,6 +40,10 @@ use WP_STATISTICS\Visitor;
 
                         <td class="wps-pd-l">
                             <span><?php echo esc_html(number_format_i18n($page->visitors)); ?></span>
+                        </td>
+
+                        <td class="wps-pd-l">
+                            <span><?php echo esc_html(round((float) ($page->bounce_rate ?? 0), 1) . '%'); ?></span>
                         </td>
 
                         <td class="wps-pd-l view-more view-more__arrow">

--- a/views/pages/visitor-insights/overview.php
+++ b/views/pages/visitor-insights/overview.php
@@ -22,6 +22,13 @@ $isTrackLoggedInUsersEnabled = Option::get('visitors_log');
         $metrics = [
             ['label' => esc_html__('Visitors', 'wp-statistics'), 'value' => Helper::formatNumberWithUnit($data['glance']['visitors']['value']), 'change' => $data['glance']['visitors']['change']],
             ['label' => esc_html__('Views', 'wp-statistics'), 'value' => Helper::formatNumberWithUnit($data['glance']['views']['value']), 'change' => $data['glance']['views']['change']],
+            [
+                'label'    => esc_html__('Bounce Rate', 'wp-statistics'),
+                'value'    => $data['glance']['bounce_rate']['value'],
+                'change'   => $data['glance']['bounce_rate']['change'],
+                'polarity' => 'negative',
+                'tooltip'  => esc_html__('Share of visits that viewed only one page. A visit is one visitor on one day.', 'wp-statistics'),
+            ],
             ['label' => esc_html__('Top Country', 'wp-statistics'), 'value' => $data['glance']['country']],
             ['label' => esc_html__('Top Referrer', 'wp-statistics'), 'link-title' => $data['glance']['referrer'], 'link-href' => Url::formatUrl($data['glance']['referrer'])],
         ];

--- a/views/pages/visitor-insights/overview.php
+++ b/views/pages/visitor-insights/overview.php
@@ -27,7 +27,7 @@ $isTrackLoggedInUsersEnabled = Option::get('visitors_log');
                 'value'    => $data['glance']['bounce_rate']['value'],
                 'change'   => $data['glance']['bounce_rate']['change'],
                 'polarity' => 'negative',
-                'tooltip'  => esc_html__('Share of visits that viewed only one page. A visit is one visitor on one day.', 'wp-statistics'),
+                'tooltip'  => esc_html__('Share of visits that recorded a single page view. A visit is one visitor on one day, and reloading a page counts as another view.', 'wp-statistics'),
             ],
             ['label' => esc_html__('Top Country', 'wp-statistics'), 'value' => $data['glance']['country']],
             ['label' => esc_html__('Top Referrer', 'wp-statistics'), 'link-title' => $data['glance']['referrer'], 'link-href' => Url::formatUrl($data['glance']['referrer'])],

--- a/wp-statistics.php
+++ b/wp-statistics.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wp-statistics.com/
  * GitHub Plugin URI: https://github.com/wp-statistics/wp-statistics
  * Description: Get website traffic insights with GDPR/CCPA compliant, privacy-friendly analytics. Includes visitor data, stunning graphs, and no data sharing.
- * Version: 14.16.10
+ * Version: 14.16.11
  * Author: VeronaLabs
  * Author URI: https://veronalabs.com/
  * Text Domain: wp-statistics
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/includes/defines.php';
 
 # Set another useful plugin define.
-define('WP_STATISTICS_VERSION', '14.16.10');
+define('WP_STATISTICS_VERSION', '14.16.11');
 
 # Load Plugin
 if (!class_exists('WP_Statistics')) {


### PR DESCRIPTION
Release branch for 14.16.11. Do not merge until the release is signed off.

## Changelog

- **New:** Bounce Rate in Visitor Insights and a Bounce Rate column in the Entry Pages report.
- **Enhancement:** Faster bounce rate calculation. Existing per-content bounce rates may shift slightly.
- **Enhancement:** New `wp_statistics_online_visitors_timeframe` filter to set how long a visitor counts as online.
- **Enhancement:** Lighter admin dashboard for users without statistics access.
- **Fix:** Email report schedules now update when the report frequency changes.
- **Enhancement:** Tested up to WordPress 7.1.

## Release housekeeping

- Version bumped to 14.16.11 in the plugin header, `WP_STATISTICS_VERSION`, and the readme stable tag.
- Changelog dated 2026-08-22 in both `CHANGELOG.md` and `readme.txt`.
- Bounce rate documented in the readme feature list and FAQ for plugin directory discoverability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bounce Rate reporting to visitor insights and entry-page tables.
  * Added a filter to customize the online-visitor timeframe, retaining a five-minute default.
* **Bug Fixes**
  * Improved email report schedule updates when frequency settings change.
  * Enhanced GeoIP database update safety, validation, cleanup, and error messages.
  * Reduced dashboard assets and metaboxes for users without statistics access.
* **Compatibility**
  * Updated WordPress compatibility testing through version 7.1.
* **Release**
  * Updated to version 14.16.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->