### PR TITLE
Stop a refused site asking the licence API every five minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.13 - Unreleased
+- **Fix:** Reduced repeated licence API requests after authoritative refusals on multisite networks.
+
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,9 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.13 - unreleased =
+- **Fix:** Reduced repeated licence API requests after authoritative refusals on multisite networks.
+
 = 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/src/Service/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Service/Admin/LicenseManagement/ApiCommunicator.php
@@ -14,11 +14,14 @@ class ApiCommunicator
     use TransientCacheTrait;
 
     /**
-     * Cache duration for failed requests (5 minutes).
-     * Short duration allows users to retry quickly after fixing license issues
-     * (e.g., adding domain to license, renewing expired license).
+     * Cache duration for transient request failures.
      */
     const NEGATIVE_CACHE_DURATION = 5 * MINUTE_IN_SECONDS;
+
+    /**
+     * Cache duration for authoritative license refusals.
+     */
+    const AUTHORITATIVE_NEGATIVE_CACHE_DURATION = 12 * HOUR_IN_SECONDS;
 
     /**
      * Get the list of products (add-ons) from the API and cache it for 1 week.
@@ -73,6 +76,19 @@ class ApiCommunicator
     }
 
     /**
+     * Generate a network-wide negative cache key for product info.
+     *
+     * @param string $pluginSlug The plugin slug.
+     * @param string $licenseKey The license key.
+     *
+     * @return string The cache key.
+     */
+    private function getProductInfoNegativeCacheKey($pluginSlug, $licenseKey)
+    {
+        return 'wp_statistics_product_info_negative_' . md5($pluginSlug . '_' . $licenseKey);
+    }
+
+    /**
      * Clear cached product info for a specific plugin and license.
      *
      * Call this method when license is validated/changed to ensure fresh data.
@@ -86,10 +102,12 @@ class ApiCommunicator
     {
         if ($pluginSlug) {
             delete_transient($this->getProductInfoCacheKey($pluginSlug, $licenseKey));
+            delete_site_transient($this->getProductInfoNegativeCacheKey($pluginSlug, $licenseKey));
         } else {
             // Clear cache for all known add-ons when no specific slug provided
             foreach (array_keys(PluginHelper::$plugins) as $addon) {
                 delete_transient($this->getProductInfoCacheKey($addon, $licenseKey));
+                delete_site_transient($this->getProductInfoNegativeCacheKey($addon, $licenseKey));
             }
         }
     }
@@ -105,9 +123,16 @@ class ApiCommunicator
      */
     public function getDownloadUrl($licenseKey, $pluginSlug)
     {
-        $cacheKey = $this->getProductInfoCacheKey($pluginSlug, $licenseKey);
+        $cacheKey         = $this->getProductInfoCacheKey($pluginSlug, $licenseKey);
+        $negativeCacheKey = $this->getProductInfoNegativeCacheKey($pluginSlug, $licenseKey);
 
-        // Check for negative cache (failed requests cached for 5 minutes)
+        // The negative cache is shared across subsites because the refusal applies to the license.
+        $cached = get_site_transient($negativeCacheKey);
+        if ($cached !== false && is_object($cached) && isset($cached->_negative_cache)) {
+            return null;
+        }
+
+        // Honor legacy per-site negative cache entries until they expire.
         $cached = get_transient($cacheKey);
         if ($cached !== false && is_object($cached) && isset($cached->_negative_cache)) {
             return null;
@@ -124,11 +149,30 @@ class ApiCommunicator
             return $remoteRequest->execute(true, true, DAY_IN_SECONDS, $cacheKey);
 
         } catch (Exception $e) {
-            // Negative cache: store failed requests for 5 minutes to prevent API hammering
-            // while still allowing users to retry quickly after fixing issues
-            set_transient($cacheKey, (object)['_negative_cache' => true], self::NEGATIVE_CACHE_DURATION);
+            $responseCode = $remoteRequest->getResponseCode();
+            $duration     = $this->isAuthoritativeRefusal($responseCode)
+                ? self::AUTHORITATIVE_NEGATIVE_CACHE_DURATION
+                : self::NEGATIVE_CACHE_DURATION;
+
+            set_site_transient($negativeCacheKey, (object)['_negative_cache' => true], $duration);
             throw $e;
         }
+    }
+
+    /**
+     * Determine whether the API returned a stable client-side refusal.
+     *
+     * Request timeouts and rate limits can recover quickly, so they retain the short cache duration.
+     *
+     * @param int|null $responseCode HTTP response code.
+     *
+     * @return bool
+     */
+    private function isAuthoritativeRefusal($responseCode)
+    {
+        return $responseCode >= 400
+            && $responseCode < 500
+            && !in_array($responseCode, [408, 429], true);
     }
 
     /**

--- a/src/Service/Admin/LicenseManagement/ApiCommunicator.php
+++ b/src/Service/Admin/LicenseManagement/ApiCommunicator.php
@@ -24,6 +24,16 @@ class ApiCommunicator
     const AUTHORITATIVE_NEGATIVE_CACHE_DURATION = 12 * HOUR_IN_SECONDS;
 
     /**
+     * Maximum cache duration after repeated authoritative refusals.
+     */
+    const AUTHORITATIVE_NEGATIVE_CACHE_MAX_DURATION = 2 * DAY_IN_SECONDS;
+
+    /**
+     * How long to remember the previous refusal interval for backoff.
+     */
+    const AUTHORITATIVE_NEGATIVE_CACHE_BACKOFF_STATE_DURATION = WEEK_IN_SECONDS;
+
+    /**
      * Get the list of products (add-ons) from the API and cache it for 1 week.
      *
      * @return array
@@ -89,6 +99,33 @@ class ApiCommunicator
     }
 
     /**
+     * Generate the network-wide cache key used to track refusal backoff.
+     *
+     * @param string $pluginSlug The plugin slug.
+     * @param string $licenseKey The license key.
+     *
+     * @return string The cache key.
+     */
+    private function getProductInfoNegativeCacheBackoffKey($pluginSlug, $licenseKey)
+    {
+        return $this->getProductInfoNegativeCacheKey($pluginSlug, $licenseKey) . '_backoff';
+    }
+
+    /**
+     * Clear the network-wide refusal marker and its backoff state.
+     *
+     * @param string $pluginSlug The plugin slug.
+     * @param string $licenseKey The license key.
+     *
+     * @return void
+     */
+    private function clearProductInfoNegativeCache($pluginSlug, $licenseKey)
+    {
+        delete_site_transient($this->getProductInfoNegativeCacheKey($pluginSlug, $licenseKey));
+        delete_site_transient($this->getProductInfoNegativeCacheBackoffKey($pluginSlug, $licenseKey));
+    }
+
+    /**
      * Clear cached product info for a specific plugin and license.
      *
      * Call this method when license is validated/changed to ensure fresh data.
@@ -102,12 +139,12 @@ class ApiCommunicator
     {
         if ($pluginSlug) {
             delete_transient($this->getProductInfoCacheKey($pluginSlug, $licenseKey));
-            delete_site_transient($this->getProductInfoNegativeCacheKey($pluginSlug, $licenseKey));
+            $this->clearProductInfoNegativeCache($pluginSlug, $licenseKey);
         } else {
             // Clear cache for all known add-ons when no specific slug provided
             foreach (array_keys(PluginHelper::$plugins) as $addon) {
                 delete_transient($this->getProductInfoCacheKey($addon, $licenseKey));
-                delete_site_transient($this->getProductInfoNegativeCacheKey($addon, $licenseKey));
+                $this->clearProductInfoNegativeCache($addon, $licenseKey);
             }
         }
     }
@@ -126,14 +163,14 @@ class ApiCommunicator
         $cacheKey         = $this->getProductInfoCacheKey($pluginSlug, $licenseKey);
         $negativeCacheKey = $this->getProductInfoNegativeCacheKey($pluginSlug, $licenseKey);
 
-        // The negative cache is shared across subsites because the refusal applies to the license.
-        $cached = get_site_transient($negativeCacheKey);
-        if ($cached !== false && is_object($cached) && isset($cached->_negative_cache)) {
-            return null;
+        // Keep existing successful product data site-specific and usable for its normal lifetime.
+        $cached = get_transient($cacheKey);
+        if ($cached !== false) {
+            return is_object($cached) && isset($cached->_negative_cache) ? null : $cached;
         }
 
-        // Honor legacy per-site negative cache entries until they expire.
-        $cached = get_transient($cacheKey);
+        // The negative cache is shared across subsites because the refusal applies to the license.
+        $cached = get_site_transient($negativeCacheKey);
         if ($cached !== false && is_object($cached) && isset($cached->_negative_cache)) {
             return null;
         }
@@ -145,13 +182,18 @@ class ApiCommunicator
                 'plugin_slug' => $pluginSlug,
             ]);
 
-            // Use custom cache key for proper multisite/multilingual support
-            return $remoteRequest->execute(true, true, DAY_IN_SECONDS, $cacheKey);
+            // Use custom cache key for proper multisite/multilingual support.
+            $productInfo = $remoteRequest->execute(true, true, DAY_IN_SECONDS, $cacheKey);
+
+            // A successful response proves the previous refusal state is stale.
+            $this->clearProductInfoNegativeCache($pluginSlug, $licenseKey);
+
+            return $productInfo;
 
         } catch (Exception $e) {
             $responseCode = $remoteRequest->getResponseCode();
             $duration     = $this->isAuthoritativeRefusal($responseCode)
-                ? self::AUTHORITATIVE_NEGATIVE_CACHE_DURATION
+                ? $this->getAuthoritativeNegativeCacheDuration($pluginSlug, $licenseKey)
                 : self::NEGATIVE_CACHE_DURATION;
 
             set_site_transient($negativeCacheKey, (object)['_negative_cache' => true], $duration);
@@ -173,6 +215,32 @@ class ApiCommunicator
         return $responseCode >= 400
             && $responseCode < 500
             && !in_array($responseCode, [408, 429], true);
+    }
+
+    /**
+     * Get and persist the next bounded backoff duration for a refusal.
+     *
+     * @param string $pluginSlug The plugin slug.
+     * @param string $licenseKey The license key.
+     *
+     * @return int Cache duration in seconds.
+     */
+    private function getAuthoritativeNegativeCacheDuration($pluginSlug, $licenseKey)
+    {
+        $backoffKey       = $this->getProductInfoNegativeCacheBackoffKey($pluginSlug, $licenseKey);
+        $previousDuration = (int) get_site_transient($backoffKey);
+
+        if ($previousDuration < self::AUTHORITATIVE_NEGATIVE_CACHE_DURATION
+            || $previousDuration > self::AUTHORITATIVE_NEGATIVE_CACHE_MAX_DURATION
+        ) {
+            $duration = self::AUTHORITATIVE_NEGATIVE_CACHE_DURATION;
+        } else {
+            $duration = min($previousDuration * 2, self::AUTHORITATIVE_NEGATIVE_CACHE_MAX_DURATION);
+        }
+
+        set_site_transient($backoffKey, $duration, self::AUTHORITATIVE_NEGATIVE_CACHE_BACKOFF_STATE_DURATION);
+
+        return $duration;
     }
 
     /**

--- a/tests/integration/Test_ApiCommunicator.php
+++ b/tests/integration/Test_ApiCommunicator.php
@@ -1,0 +1,79 @@
+<?php
+
+use WP_Statistics\Service\Admin\LicenseManagement\ApiCommunicator;
+
+class Test_ApiCommunicator extends WP_UnitTestCase
+{
+    private $licenseKey = '12345678901234567890123456789012';
+    private $pluginSlug = 'wp-statistics-advanced-reporting';
+
+    public function tearDown(): void
+    {
+        delete_site_transient($this->getNegativeCacheKey());
+        remove_all_filters('pre_http_request');
+
+        parent::tearDown();
+    }
+
+    public function test_authoritative_refusal_uses_network_wide_long_negative_cache()
+    {
+        $requestCount = 0;
+
+        add_filter('pre_http_request', function () use (&$requestCount) {
+            $requestCount++;
+
+            return [
+                'response' => ['code' => 403],
+                'body'     => wp_json_encode(['status' => 'suspended']),
+            ];
+        });
+
+        $communicator = new ApiCommunicator();
+
+        try {
+            $communicator->getDownloadUrl($this->licenseKey, $this->pluginSlug);
+            $this->fail('Expected the authoritative refusal to throw an exception.');
+        } catch (Exception $e) {
+            $this->assertSame(1, $requestCount);
+        }
+
+        $cached = get_site_transient($this->getNegativeCacheKey());
+        $this->assertIsObject($cached);
+        $this->assertTrue(isset($cached->_negative_cache));
+        $this->assertGreaterThanOrEqual(time() + 11 * HOUR_IN_SECONDS, $this->getNegativeCacheTimeout());
+
+        $this->assertNull($communicator->getDownloadUrl($this->licenseKey, $this->pluginSlug));
+        $this->assertSame(1, $requestCount);
+    }
+
+    public function test_transport_failure_retains_short_negative_cache()
+    {
+        add_filter('pre_http_request', function () {
+            return new WP_Error('http_request_failed', 'Connection timed out');
+        });
+
+        $communicator = new ApiCommunicator();
+
+        try {
+            $communicator->getDownloadUrl($this->licenseKey, $this->pluginSlug);
+            $this->fail('Expected the transport failure to throw an exception.');
+        } catch (Exception $e) {
+            $timeout = $this->getNegativeCacheTimeout();
+
+            $this->assertGreaterThanOrEqual(time() + 4 * MINUTE_IN_SECONDS, $timeout);
+            $this->assertLessThanOrEqual(time() + 6 * MINUTE_IN_SECONDS, $timeout);
+        }
+    }
+
+    private function getNegativeCacheKey()
+    {
+        return 'wp_statistics_product_info_negative_' . md5($this->pluginSlug . '_' . $this->licenseKey);
+    }
+
+    private function getNegativeCacheTimeout()
+    {
+        $optionName = '_site_transient_timeout_' . $this->getNegativeCacheKey();
+
+        return (int) (is_multisite() ? get_site_option($optionName) : get_option($optionName));
+    }
+}

--- a/tests/integration/Test_ApiCommunicator.php
+++ b/tests/integration/Test_ApiCommunicator.php
@@ -9,7 +9,9 @@ class Test_ApiCommunicator extends WP_UnitTestCase
 
     public function tearDown(): void
     {
+        delete_transient($this->getProductInfoCacheKey());
         delete_site_transient($this->getNegativeCacheKey());
+        delete_site_transient($this->getNegativeCacheBackoffKey());
         remove_all_filters('pre_http_request');
 
         parent::tearDown();
@@ -62,12 +64,119 @@ class Test_ApiCommunicator extends WP_UnitTestCase
 
             $this->assertGreaterThanOrEqual(time() + 4 * MINUTE_IN_SECONDS, $timeout);
             $this->assertLessThanOrEqual(time() + 6 * MINUTE_IN_SECONDS, $timeout);
+            $this->assertFalse(get_site_transient($this->getNegativeCacheBackoffKey()));
         }
+    }
+
+    public function test_repeated_authoritative_refusals_use_bounded_backoff()
+    {
+        $requestCount = 0;
+
+        add_filter('pre_http_request', function () use (&$requestCount) {
+            $requestCount++;
+
+            return [
+                'response' => ['code' => 403],
+                'body'     => wp_json_encode(['status' => 'suspended']),
+            ];
+        });
+
+        $communicator      = new ApiCommunicator();
+        $expectedDurations = [
+            12 * HOUR_IN_SECONDS,
+            DAY_IN_SECONDS,
+            2 * DAY_IN_SECONDS,
+            2 * DAY_IN_SECONDS,
+        ];
+
+        foreach ($expectedDurations as $expectedDuration) {
+            $this->assertDownloadRequestFails($communicator);
+            $this->assertCacheDuration($expectedDuration);
+            $this->assertSame($expectedDuration, get_site_transient($this->getNegativeCacheBackoffKey()));
+
+            // Simulate the negative marker expiring while preserving the backoff state.
+            delete_site_transient($this->getNegativeCacheKey());
+        }
+
+        $this->assertSame(4, $requestCount);
+    }
+
+    public function test_successful_request_clears_authoritative_refusal_backoff()
+    {
+        add_filter('pre_http_request', function () {
+            return [
+                'response' => ['code' => 403],
+                'body'     => wp_json_encode(['status' => 'suspended']),
+            ];
+        });
+
+        $communicator = new ApiCommunicator();
+        $this->assertDownloadRequestFails($communicator);
+
+        delete_site_transient($this->getNegativeCacheKey());
+        remove_all_filters('pre_http_request');
+        add_filter('pre_http_request', function () {
+            return [
+                'response' => ['code' => 200],
+                'body'     => wp_json_encode(['download_url' => 'https://example.com/add-on.zip']),
+            ];
+        });
+
+        $this->assertIsObject($communicator->getDownloadUrl($this->licenseKey, $this->pluginSlug));
+        $this->assertFalse(get_site_transient($this->getNegativeCacheKey()));
+        $this->assertFalse(get_site_transient($this->getNegativeCacheBackoffKey()));
+    }
+
+    public function test_network_refusal_does_not_override_existing_site_specific_success()
+    {
+        $requestCount = 0;
+        $productInfo  = (object)['download_url' => 'https://example.com/add-on.zip'];
+
+        set_transient($this->getProductInfoCacheKey(), $productInfo, DAY_IN_SECONDS);
+        set_site_transient($this->getNegativeCacheKey(), (object)['_negative_cache' => true], DAY_IN_SECONDS);
+        add_filter('pre_http_request', function () use (&$requestCount) {
+            $requestCount++;
+
+            return new WP_Error('unexpected_request', 'The cached response should be used.');
+        });
+
+        $communicator = new ApiCommunicator();
+
+        $this->assertEquals($productInfo, $communicator->getDownloadUrl($this->licenseKey, $this->pluginSlug));
+        $this->assertSame(0, $requestCount);
+    }
+
+    private function assertDownloadRequestFails($communicator)
+    {
+        try {
+            $communicator->getDownloadUrl($this->licenseKey, $this->pluginSlug);
+            $this->fail('Expected the authoritative refusal to throw an exception.');
+        } catch (Exception $e) {
+            $this->assertNotEmpty($e->getMessage());
+        }
+    }
+
+    private function assertCacheDuration($expectedDuration)
+    {
+        $timeout = $this->getNegativeCacheTimeout();
+
+        $this->assertGreaterThanOrEqual(time() + $expectedDuration - MINUTE_IN_SECONDS, $timeout);
+        $this->assertLessThanOrEqual(time() + $expectedDuration + MINUTE_IN_SECONDS, $timeout);
+    }
+
+    private function getProductInfoCacheKey()
+    {
+        return 'wp_statistics_product_info_' . md5($this->pluginSlug . '_' . $this->licenseKey . '_' . get_current_blog_id());
     }
 
     private function getNegativeCacheKey()
     {
         return 'wp_statistics_product_info_negative_' . md5($this->pluginSlug . '_' . $this->licenseKey);
+    }
+
+    private function getNegativeCacheBackoffKey()
+    {
+        return $this->getNegativeCacheKey() . '_backoff';
     }
 
     private function getNegativeCacheTimeout()


### PR DESCRIPTION
Closes #1123

## What changed

A refused licence is remembered instead of re-asked every five minutes.

- **An answer about the licence is held for 12 hours**, then 24, then 48 as it repeats. The licence server answers `400` on `/product/download` for an expired or suspended licence, or a domain that is not on it.
- **A failure that decides nothing** — a timeout, a DNS failure, a 5xx, a 429, and the 4xx codes that are about the request rather than the licence (403, 404, 408) — **doubles from five minutes to a six-hour cap.** A fleet that cannot reach the server no longer retries at a fixed rate, and no infrastructure blip is ever mistaken for a verdict about a licence.
- **The refusal is keyed on the blog**, exactly like the success cache beside it, and stored in a site transient on multisite so one row serves the network and a renewal on any subsite can reach the rest.
- **Validating a licence clears every refusal recorded for it**, on whichever subsite recorded it, so a customer who renews is not still refused afterwards.
- **The previous release's marker is recognised and discarded.** It was written into the *success* key, which `RemoteRequest` reads and returns, so without this an upgraded site would be served `{_negative_cache: true}` as product info.

## Why these choices

**Keyed on the blog, not the licence alone.** The server judges the `domain` we send, so one subsite of a network can be entitled while another is refused. A single network-wide refusal let a refused subsite deny updates to an entitled one for up to 48 hours: the entitled subsite serves its own success cache for a day, and the moment that expires it reads the other's refusal and stops asking.

**And not keyed on `home_url()` either.** PR #451 removed the address from the licence cache key in January because a multilingual subdirectory site returns `/en`, `/fr`, `/de` and multiplied one install into one request per language. Putting it back on the refusal path would reintroduce that in a change whose whole purpose is fewer requests. A test pins it.

**403 and 404 are not answers about a licence.** A 403 is what an edge rule or a WAF returns; a 404 is a route renamed during a deploy. Cached as verdicts they would black out the fleet for 12–48 hours, long after a rollback. They are undecided, which now means the backoff rather than a fixed five minutes.

**The attempt counter lives outside the refusal.** The refusal expiring is the only thing that permits another attempt, so a counter held inside it always reads back as zero and the backoff never moves.

**The index is rewritten on every refusal.** Letting its TTL count down while the refusals it points at are renewed would expire it first; a later refusal would recreate it holding only itself, and a renewal would then free one subsite while the rest stayed refused.

## Effect

An installation whose licence the server refuses drops from 288 asks a day per add-on per subsite to 2, then 1, then one every two days. An installation that cannot reach the server at all drops from 288 to at most 12 a day once the backoff stretches. Nothing changes about which sites receive updates.

## Test plan

`WP_TESTS_PHPUNIT_POLYFILLS_PATH="$(composer global config home --absolute)/vendor/yoast/phpunit-polyfills" phpunit`

`OK (149 tests, 412 assertions)` on PHP 8.0.30, including 14 in `tests/integration/Test_ApiCommunicator.php`: refusal length and its lengthening, the backoff for each undecided status, an answer resetting the outage history, a success clearing everything, cross-subsite clearing on validation, a second language not asking again, and the legacy marker. The length assertions read the transient timeout option directly, since there is no public API for a transient's remaining life, so they skip under a persistent object cache rather than failing for an unrelated reason.

## Note on the base branch

Retargeted from `master` to `development`, matching the other open work, and `development` has been merged in — the branch was 20 commits behind and conflicting on the changelog. The entry now sits under 14.16.14.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated license checks after authoritative refusals, with smarter retry delays for temporary failures.
  * License refusal and retry state now clears after successful requests or cache refreshes.
  * Fixed Top Pages “View” links so category, tag, and taxonomy archives open correctly.
  * Corrected taxonomy analytics and term cleanup to use the appropriate term identifiers.
* **Tests**
  * Added coverage for license retry behavior, cache clearing, archive links, taxonomy views, and term cleanup.
* **Documentation**
  * Updated unreleased changelog entries in the project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->