### PR TITLE
Restore date picker for authorized custom roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.13 - Unreleased
+- **Fix:** Restored complete date range controls for authorized custom roles on analytics pages.
+
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -144,7 +144,8 @@ class Admin_Assets
      */
     public function admin_styles()
     {
-        if (!User::Access()) {
+        // WordPress has already enforced the registered menu capability on plugin pages.
+        if (!Menus::in_plugin_page() && !User::Access()) {
             return;
         }
 
@@ -188,7 +189,8 @@ class Admin_Assets
      */
     public function admin_scripts($hook)
     {
-        if (!User::Access()) {
+        // WordPress has already enforced the registered menu capability on plugin pages.
+        if (!Menus::in_plugin_page() && !User::Access()) {
             return;
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,9 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.13 - Unreleased =
+- **Fix:** Restored complete date range controls for authorized custom roles on analytics pages.
+
 = 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -2,6 +2,7 @@
 
 use WP_Statistics\Service\Admin\Metabox\MetaboxManager;
 use WP_STATISTICS\Admin_Assets;
+use WP_STATISTICS\Menus;
 use WP_STATISTICS\Option;
 use WP_STATISTICS\User;
 
@@ -33,6 +34,9 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
     public function tearDown(): void
     {
+        global $pagenow;
+
+        remove_filter('wp_statistics_admin_menu_list', [$this, 'grantContentAnalyticsAccess']);
         remove_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
         remove_action('admin_init', [$this->metaboxManager, 'registerMetaboxes']);
         remove_action('admin_init', [$this->metaboxManager, 'hideDashboardMetaboxes']);
@@ -48,7 +52,10 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
         remove_role('wps_manager_only');
         remove_role('wps_reader_only');
+        remove_role('wps_content_analyst');
         wp_set_current_user(0);
+        unset($_REQUEST['page']);
+        $pagenow = 'index.php';
         set_current_screen('front');
 
         parent::tearDown();
@@ -150,6 +157,44 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
         $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertSame(0, $this->metaboxListCalls);
+    }
+
+    public function test_custom_role_admitted_to_content_analytics_receives_date_picker_assets()
+    {
+        global $pagenow;
+
+        add_role(
+            'wps_content_analyst',
+            'WP Statistics Content Analyst',
+            [
+                'read'                       => true,
+                'wps_view_content_analytics' => true,
+            ]
+        );
+
+        add_filter('wp_statistics_admin_menu_list', [$this, 'grantContentAnalyticsAccess']);
+        $this->setCurrentUserWithRole('wps_content_analyst');
+
+        $menu = Menus::get_menu_list();
+        $this->assertTrue(current_user_can($menu['content_analytics']['cap']));
+        $this->assertFalse(User::Access());
+
+        $pagenow          = 'admin.php';
+        $_REQUEST['page'] = Menus::get_page_slug('content-analytics');
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('statistics_page_wps_content-analytics_page');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+    }
+
+    public function grantContentAnalyticsAccess(array $menus): array
+    {
+        $menus['content_analytics']['cap'] = 'wps_view_content_analytics';
+
+        return $menus;
     }
 
     private function setCurrentUserWithRole(string $role): void

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -185,9 +185,19 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
         $this->assets->admin_styles();
         $this->assets->admin_scripts('statistics_page_wps_content-analytics_page');
 
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_style_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix . '-customize', 'enqueued'));
+        $this->assertTrue(wp_script_is('moment', 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+
+        $localizedData = wp_scripts()->get_data(Admin_Assets::$prefix, 'data');
+        $this->assertIsString($localizedData);
+        $this->assertStringContainsString('var wps_global = ', $localizedData);
+        $this->assertStringContainsString('"str_custom":', $localizedData);
+        $this->assertStringContainsString('"from":', $localizedData);
+        $this->assertStringContainsString('"to":', $localizedData);
     }
 
     public function grantContentAnalyticsAccess(array $menus): array


### PR DESCRIPTION
## What changed
- keep the early admin-asset guard on dashboard and other non-plugin screens
- trust WordPress's already-enforced menu capability on WP Statistics plugin pages, so authorized custom roles receive the admin, localization, and date-range assets
- add focused coverage for a custom non-admin role admitted to Content Analytics and document the fix for the next release

## Why
The static `Last 30 Days` markup only becomes a complete date range control after the WP Statistics admin bundle, localization payload, and date-range assets load. The global `User::Access()` guard could reject a custom role even after WordPress had admitted that role to a registered WP Statistics page, leaving only the static label. Plugin pages now use the page capability WordPress already checked, while unauthorized dashboard users remain protected by the existing access guard.

## Test plan
- `WP_TESTS_PHPUNIT_POLYFILLS_PATH=/root/.composer/vendor/yoast/phpunit-polyfills phpunit --filter Test_AdminAccessGuards --testdox` — **6 tests, 27 assertions passed**
- `php -l includes/admin/class-wp-statistics-admin-assets.php`
- `php -l tests/unit/Test_AdminAccessGuards.php`
- `git diff --check`

## Manual verification
1. Configure a non-administrator custom role with access to WP Statistics Content Analytics.
2. Sign in as a user with that role and open **WP Statistics → Content Analytics**.
3. Confirm the date range includes the resolved range text, opens the picker, and applies a new range.
4. Confirm a user without WP Statistics access still receives no WP Statistics assets on the dashboard.

Closes #1126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored complete date-range controls on analytics pages for authorized custom roles.
  * Ensured analytics page styling and functionality load correctly for users with granted access.

* **Documentation**
  * Added an unreleased 14.16.13 changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
