### PR TITLE
Guard date keys in Query::whereDate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.13 - unreleased
+- **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
+
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,10 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
-= 14.16.12 - 2026-08-31
+= 14.16.13 - unreleased =
+- **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
+
+= 14.16.12 - 2026-08-31 =
 - **Enhancement:** General security hardening and internal improvements.
 
 = 14.16.11 - 2026-08-22 =

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -189,6 +189,9 @@ class Query
     {
         if (empty($date)) return $this;
 
+        $from = '';
+        $to   = '';
+
         if (is_array($date)) {
             $from = isset($date['from']) ? $date['from'] : '';
             $to   = isset($date['to']) ? $date['to'] : '';
@@ -196,8 +199,8 @@ class Query
 
         if (is_string($date)) {
             $date = DateRange::get($date);
-            $from = $date['from'];
-            $to   = $date['to'];
+            $from = isset($date['from']) ? $date['from'] : '';
+            $to   = isset($date['to']) ? $date['to'] : '';
         }
 
         if (!empty($from) && !empty($to)) {

--- a/wp-statistics.php
+++ b/wp-statistics.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wp-statistics.com/
  * GitHub Plugin URI: https://github.com/wp-statistics/wp-statistics
  * Description: Get website traffic insights with GDPR/CCPA compliant, privacy-friendly analytics. Includes visitor data, stunning graphs, and no data sharing.
- * Version: 14.16.12
+ * Version: 14.16.13
  * Author: VeronaLabs
  * Author URI: https://veronalabs.com/
  * Text Domain: wp-statistics
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/includes/defines.php';
 
 # Set another useful plugin define.
-define('WP_STATISTICS_VERSION', '14.16.12');
+define('WP_STATISTICS_VERSION', '14.16.13');
 
 # Load Plugin
 if (!class_exists('WP_Statistics')) {


### PR DESCRIPTION
Fixes #1130

## Problem

`DateRange::get()` starts with an empty array and only fills `from`/`to` when the period name matches a key in `getPeriods()` (or is `total`). Any other string comes back as an empty array.

`Query::whereDate()` read `$date['from']` and `$date['to']` from that result without a guard, so an unrecognized period produced two "Undefined array key" warnings per call on PHP 8. The array-input branch directly above already guarded its keys.

## Change

Initialize `$from` and `$to` before both branches, and read the string-branch keys with `isset()` so the two branches behave the same way. An unrecognized period now degrades to a no-op date filter instead of warning, and the later `canUseCacheForDateRange($to)` call always receives a defined value — including when `$date` is neither an array nor a string.

## Testing

- Confirmed the warnings on `whereDate($field, 'some_unknown_period')` with `WP_DEBUG_LOG` enabled, and confirmed they are gone after the change.
- Recognized periods are unaffected: the same `BETWEEN` clause is built and the same caching decision is made.

## Note for reviewers

One pre-existing behavior is worth a separate look and is deliberately left alone here. When no date range is resolved, no `BETWEEN` clause is added, but `canUseCacheForDateRange('')` still evaluates `'' < today` as true and enables caching — so an unbounded all-time result can be cached. The `empty($date)` early return at the top of the method skips that call entirely, so the two "no date filter" paths behave differently. Happy to open a follow-up issue if that is worth changing.

Reported by @HFigarella.