### PR TITLE
Honour per-page and user-level capabilities for admin access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+14.16.13 - unreleased
+- **Fix:** Custom roles granted access to a single analytics page now get the full date range picker and page data again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
+- **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.
+
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -144,7 +144,7 @@ class Admin_Assets
      */
     public function admin_styles()
     {
-        if (!User::Access()) {
+        if (!User::hasPageAccess()) {
             return;
         }
 
@@ -188,7 +188,7 @@ class Admin_Assets
      */
     public function admin_scripts($hook)
     {
-        if (!User::Access()) {
+        if (!User::hasPageAccess()) {
             return;
         }
 

--- a/includes/class-wp-statistics-menus.php
+++ b/includes/class-wp-statistics-menus.php
@@ -290,7 +290,7 @@ class Menus
         $currentPage = reset($currentPage);
 
         $currentPage = array_filter($pagesList, function ($page) use ($currentPage) {
-            return $page['page_url'] === $currentPage;
+            return isset($page['page_url']) && $page['page_url'] === $currentPage;
         });
 
         return reset($currentPage);

--- a/includes/class-wp-statistics-user.php
+++ b/includes/class-wp-statistics-user.php
@@ -198,8 +198,17 @@ class User
         switch ($type) {
             case "manage":
             case "read":
-                return current_user_can(self::ExistCapability(Option::get($list[$cap][0], $list[$cap][1])));
-                break;
+                $capability = Option::get($list[$cap][0], $list[$cap][1]);
+
+                // Honour the configured capability as it is, so grants made on the user
+                // rather than the role are recognised too.
+                if (!empty($capability) && current_user_can($capability)) {
+                    return true;
+                }
+
+                // Fall back to the resolved capability, which degrades to manage_options
+                // when the configured one is not registered on any role.
+                return current_user_can(self::ExistCapability($capability));
             case "both":
                 foreach (array('manage', 'read') as $c) {
                     if (self::Access($c) === true) {
@@ -210,6 +219,36 @@ class User
         }
 
         return false;
+    }
+
+    /**
+     * Check User Access To The WP Statistics Admin Page Being Requested
+     *
+     * Page capabilities can be replaced one page at a time through the
+     * `wp_statistics_admin_menu_list` filter, so a role can be admitted to a single
+     * page without holding the global read or manage capability. Outside plugin pages
+     * this is the plain access check.
+     *
+     * @return bool
+     */
+    public static function hasPageAccess()
+    {
+        if (self::Access() === true) {
+            return true;
+        }
+
+        if (!Menus::in_plugin_page()) {
+            return false;
+        }
+
+        $page = Menus::getCurrentPage();
+
+        // Pages without their own capability are covered by the check above.
+        if (empty($page['cap'])) {
+            return false;
+        }
+
+        return current_user_can($page['cap']);
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,10 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.13 - unreleased =
+- **Fix:** Custom roles granted access to a single analytics page now get the full date range picker and page data again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
+- **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.
+
 = 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -2,6 +2,7 @@
 
 use WP_Statistics\Service\Admin\Metabox\MetaboxManager;
 use WP_STATISTICS\Admin_Assets;
+use WP_STATISTICS\Menus;
 use WP_STATISTICS\Option;
 use WP_STATISTICS\User;
 
@@ -33,6 +34,9 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
     public function tearDown(): void
     {
+        global $pagenow;
+
+        remove_filter('wp_statistics_admin_menu_list', [$this, 'restrictContentAnalyticsToCustomCap'], 20);
         remove_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
         remove_action('admin_init', [$this->metaboxManager, 'registerMetaboxes']);
         remove_action('admin_init', [$this->metaboxManager, 'hideDashboardMetaboxes']);
@@ -48,7 +52,10 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
         remove_role('wps_manager_only');
         remove_role('wps_reader_only');
+        remove_role('wps_content_analyst');
         wp_set_current_user(0);
+        unset($_REQUEST['page']);
+        $pagenow = 'index.php';
         set_current_screen('front');
 
         parent::tearDown();
@@ -150,6 +157,116 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
         $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertSame(0, $this->metaboxListCalls);
+    }
+
+    public function test_custom_role_admitted_to_a_plugin_page_receives_admin_assets()
+    {
+        global $pagenow;
+
+        add_role(
+            'wps_content_analyst',
+            'WP Statistics Content Analyst',
+            [
+                'read'                       => true,
+                'wps_view_content_analytics' => true,
+            ]
+        );
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        add_filter('wp_statistics_admin_menu_list', [$this, 'restrictContentAnalyticsToCustomCap'], 20);
+        $this->setCurrentUserWithRole('wps_content_analyst');
+
+        $this->assertFalse(User::Access());
+
+        $pagenow          = 'admin.php';
+        $_REQUEST['page'] = Menus::get_page_slug('content-analytics');
+
+        $this->assertTrue(User::hasPageAccess());
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('statistics_page_wps_content-analytics_page');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+
+        $localizedData = wp_scripts()->get_data(Admin_Assets::$prefix, 'data');
+        $this->assertIsString($localizedData);
+        $this->assertStringContainsString('"user_date_range"', $localizedData);
+        $this->assertStringContainsString('"from":', $localizedData);
+        $this->assertStringContainsString('"to":', $localizedData);
+    }
+
+    public function test_users_without_the_page_capability_receive_no_assets_on_a_plugin_page_slug()
+    {
+        global $pagenow;
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        add_filter('wp_statistics_admin_menu_list', [$this, 'restrictContentAnalyticsToCustomCap'], 20);
+        $this->setCurrentUserWithRole('subscriber');
+
+        $pagenow          = 'admin.php';
+        $_REQUEST['page'] = Menus::get_page_slug('content-analytics');
+
+        $this->assertFalse(User::hasPageAccess());
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('statistics_page_wps_content-analytics_page');
+
+        $this->assertFalse(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertFalse(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    public function test_capability_granted_on_the_user_instead_of_the_role_is_honoured()
+    {
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        $userId = self::factory()->user->create(['role' => 'subscriber']);
+        $user   = get_user_by('id', $userId);
+        $user->add_cap('wps_read_stats');
+        wp_set_current_user($userId);
+
+        // No role carries the capability, so the resolver still degrades to manage_options.
+        $this->assertSame('manage_options', User::ExistCapability('wps_read_stats'));
+
+        $this->assertTrue(User::Access('read'));
+        $this->assertFalse(User::Access('manage'));
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    /**
+     * Mimics an add-on that hands a single analytics page its own capability,
+     * which is how Roles and Permissions admits a custom role to one page.
+     */
+    public function restrictContentAnalyticsToCustomCap(array $menus): array
+    {
+        $existing = isset($menus['content_analytics']) ? $menus['content_analytics'] : [];
+
+        $menus['content_analytics'] = array_merge($existing, [
+            'sub'      => 'overview',
+            'title'    => 'Content Analytics',
+            'page_url' => 'content-analytics',
+            'cap'      => 'wps_view_content_analytics',
+        ]);
+
+        return $menus;
     }
 
     private function setCurrentUserWithRole(string $role): void

--- a/wp-statistics.php
+++ b/wp-statistics.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wp-statistics.com/
  * GitHub Plugin URI: https://github.com/wp-statistics/wp-statistics
  * Description: Get website traffic insights with GDPR/CCPA compliant, privacy-friendly analytics. Includes visitor data, stunning graphs, and no data sharing.
- * Version: 14.16.12
+ * Version: 14.16.13
  * Author: VeronaLabs
  * Author URI: https://veronalabs.com/
  * Text Domain: wp-statistics
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/includes/defines.php';
 
 # Set another useful plugin define.
-define('WP_STATISTICS_VERSION', '14.16.12');
+define('WP_STATISTICS_VERSION', '14.16.13');
 
 # Load Plugin
 if (!class_exists('WP_Statistics')) {


### PR DESCRIPTION
Fixes #1126. Supersedes #1128 — happy to close either one, whichever you prefer.

## Problem

Two separate gaps stop a legitimately authorized non-administrator from receiving the WP Statistics admin assets. Without them the date range control never becomes a real picker; it stays as the static `Last 30 days` label. Administrators pass both checks, which is why granting Administrator "fixes" it.

**1. Per-page capabilities are ignored.** A page's capability can be replaced one page at a time through the `wp_statistics_admin_menu_list` filter, which is how a role is admitted to a single analytics page such as Content Analytics. `Admin_Assets::admin_styles()` and `admin_scripts()` checked only the global read/manage capability, so the role was refused even though WordPress had already admitted it to the page and rendered it. This is the case in the report.

**2. Capabilities held by the user rather than the role are ignored.** `User::Access()` resolved the configured capability through `ExistCapability()`, which returns `manage_options` whenever the capability is not registered on any role object. A capability granted with `WP_User::add_cap()` or through the `user_has_cap` filter therefore degraded to an administrator-only check.

## Change

`User::hasPageAccess()` answers "is this user allowed on the WP Statistics page being requested". It starts from the existing global check and, on a plugin page, falls back to the capability that page actually declares. It verifies that capability with `current_user_can()` rather than trusting the request, so a user without it still receives nothing. The two asset guards now use it.

`User::Access()` tests the configured capability directly before falling back to the resolved one. The fallback is kept on purpose: checking the configured capability alone would mean a stale or misspelled setting locks administrators out too, which is what `ExistCapability()` exists to prevent. The change only ever widens access to users who genuinely hold the configured capability.

`Menus::getCurrentPage()` read `page_url` without a guard, which warned on menu entries that do not declare one.

## Deliberately unchanged

The `meta_boxes` payload stays on the global read check. The admin-ajax endpoint behind those metaboxes runs with `$pagenow` set to `admin-ajax.php`, where the requested page is not visible, so widening only the payload would render metaboxes that can never load their data — worse than the empty payload it replaced.

For the same reason the AJAX filter endpoints in `FilterManager` still use the global check, so a page-admitted role gets working assets and a working date range picker but empty post type, author and URL filter dropdowns. The date range picker itself navigates by URL rather than AJAX, so the reported symptom is fixed. Worth a follow-up issue if you want those dropdowns covered too.

## Tests

Three cases added to `Test_AdminAccessGuards`:

- a custom role admitted to Content Analytics by a per-page capability receives the admin bundle, the date range picker assets, and a localized payload carrying the resolved range
- a user without that capability still receives nothing, even with the plugin page slug in the request
- a capability granted on the user rather than the role is honoured, with an assertion that the resolver still degrades to `manage_options` so the test fails if the fallback is what makes it pass

Full suite: **129 tests, 288 assertions, all passing** (PHP 8.0.30, PHPUnit 9.6.21).

## Manual verification

1. Give a non-administrator custom role access to a single analytics page through Roles and Permissions.
2. Sign in as that user and open **WP Statistics → Content Analytics**.
3. The date range shows the resolved range text, the picker opens, and applying a range reloads with the new range.
4. A user with no WP Statistics access still receives no assets, on the dashboard and on a plugin page slug alike.