### PR TITLE
Guard tracker debugger checks against PHP 8.5 SPL deprecations

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
+        php-version: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
     services:
       database:
         image: mysql:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 14.16.13 - unreleased
+- **Dev:** Added PHP 8.5 test coverage for deprecated `SplObjectStorage` method calls in tracker debugger checks (issue [#1133](https://github.com/wp-statistics/wp-statistics/issues/1133)).
 - **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
 - **Fix:** Custom roles granted access to a single analytics page now get the full date range picker again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
 - **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.

--- a/tests/integration/Test_TrackerDebuggerPhp85.php
+++ b/tests/integration/Test_TrackerDebuggerPhp85.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WP_Statistics\Tests\Service\Debugger;
+
+use WP_Statistics\Option;
+use WP_Statistics\Service\Debugger\DebuggerFactory;
+use WP_UnitTestCase;
+
+class Test_TrackerDebuggerPhp85 extends WP_UnitTestCase
+{
+    /**
+     * Ensure the debugger's tracker checks remain free of PHP deprecations.
+     */
+    public function test_tracker_checks_do_not_emit_deprecations()
+    {
+        add_filter('pre_http_request', static function () {
+            return [
+                'headers'  => [],
+                'body'     => '{"status":true}',
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'cookies'  => [],
+                'filename' => null,
+            ];
+        });
+
+        $previousOptions = Option::getOptions();
+        $deprecations    = [];
+
+        set_error_handler(static function ($severity, $message, $file, $line) use (&$deprecations) {
+            if (in_array($severity, [E_DEPRECATED, E_USER_DEPRECATED], true)) {
+                $deprecations[] = sprintf('%s:%d %s', $file, $line, $message);
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            foreach ([false, true] as $bypassAdBlockers) {
+                Option::update('bypass_ad_blockers', $bypassAdBlockers);
+                (new DebuggerFactory())->getAllProviders();
+            }
+        } finally {
+            restore_error_handler();
+            Option::save_options($previousOptions);
+        }
+
+        $this->assertSame([], $deprecations, implode("\n", $deprecations));
+    }
+}


### PR DESCRIPTION
## What changed
- Added PHP 8.5 to the PHPUnit CI matrix.
- Added a focused integration regression that exercises both tracker debugger request modes while capturing PHP deprecations.
- Documented the compatibility coverage in the 14.16.13 changelog.

## Why
A direct PHP 8.5 control reproduces the reported warning when `SplObjectStorage::attach()` is called. Auditing WP Statistics application sources, Composer packages, generated/scoped dependencies, and the published 14.16.12 plugin artifact found no such call. Running the real tracker debugger provider path under PHP 8.5 likewise emits no deprecations, so the observed call comes from unrelated runtime code loaded alongside the tracker request rather than WP Statistics or its bundled dependencies.

This PR keeps that boundary verifiable: future WP Statistics or dependency changes that introduce a deprecated SPL call into either REST or ad-blocker-bypass tracker checks will fail the PHP 8.5 lane.

## How to test
On PHP 8.5 with the WordPress PHPUnit environment configured:

```bash
WP_CORE_DIR=/path/to/wordpress \
WP_TESTS_DIR=/path/to/wordpress-tests-lib \
WP_TESTS_PHPUNIT_POLYFILLS_PATH=/path/to/phpunit-polyfills \
phpunit --testdox tests/integration/Test_TrackerDebuggerPhp85.php
```

Result: `OK (1 test, 1 assertion)` on PHP 8.5.10. The existing WordPress test bootstrap printed missing WP Statistics table notices before test execution; the focused tracker check itself emitted no PHP deprecations.

A direct negative control on the same PHP binary produced the reported `SplObjectStorage::attach()` deprecation, confirming the runtime would detect it.

Closes #1133
