### PR TITLE
Release 14.16.13

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
+        php-version: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
     services:
       database:
         image: mysql:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+14.16.13 - unreleased
+- **Fix:** Custom roles granted access to a single analytics page now get the full date range picker and page data again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
+- **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.
+
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.13 - unreleased
+- **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
+
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 14.16.13 - unreleased
+- **Fix:** Category Analytics report links now use term IDs instead of taxonomy IDs.
 - **Dev:** Added PHP 8.5 test coverage for deprecated `SplObjectStorage` method calls in tracker debugger checks (issue [#1133](https://github.com/wp-statistics/wp-statistics/issues/1133)).
 - **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
 - **Fix:** Custom roles granted access to a single analytics page now get the full date range picker again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
@@ -6,7 +7,6 @@
 
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
-- **Fix:** Category Analytics report links now use term IDs instead of taxonomy IDs.
 
 14.16.11 - 2026-08-22
 - **New:** Bounce Rate in Visitor Insights and a Bounce Rate column in the Entry Pages report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
+- **Fix:** Category Analytics report links now use term IDs instead of taxonomy IDs.
 
 14.16.11 - 2026-08-22
 - **New:** Bounce Rate in Visitor Insights and a Bounce Rate column in the Entry Pages report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 14.16.13 - unreleased
+- **Dev:** Added PHP 8.5 test coverage for deprecated `SplObjectStorage` method calls in tracker debugger checks (issue [#1133](https://github.com/wp-statistics/wp-statistics/issues/1133)).
 - **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
 - **Fix:** Custom roles granted access to a single analytics page now get the full date range picker again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
 - **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-14.16.13 - unreleased
-- **Fix:** Category Analytics report links now use term IDs instead of taxonomy IDs.
-- **Dev:** Added PHP 8.5 test coverage for deprecated `SplObjectStorage` method calls in tracker debugger checks (issue [#1133](https://github.com/wp-statistics/wp-statistics/issues/1133)).
-- **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
-- **Fix:** Custom roles granted access to a single analytics page now get the full date range picker again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
-- **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.
+14.16.13 - 2026-09-05
+- **Fix:** Corrected report links in Category Analytics.
+- **Fix:** Date filters no longer trigger PHP warnings when the period name is unrecognized (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
+- **Fix:** Analytics page access and the date range picker now work correctly for custom roles and per-user capabilities (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
+- **Enhancement:** Internal improvements and PHP 8.5 compatibility.
 
 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.

--- a/includes/admin/class-wp-statistics-admin-assets.php
+++ b/includes/admin/class-wp-statistics-admin-assets.php
@@ -144,7 +144,7 @@ class Admin_Assets
      */
     public function admin_styles()
     {
-        if (!User::Access()) {
+        if (!User::hasPageAccess()) {
             return;
         }
 
@@ -188,7 +188,7 @@ class Admin_Assets
      */
     public function admin_scripts($hook)
     {
-        if (!User::Access()) {
+        if (!User::hasPageAccess()) {
             return;
         }
 

--- a/includes/class-wp-statistics-menus.php
+++ b/includes/class-wp-statistics-menus.php
@@ -290,7 +290,7 @@ class Menus
         $currentPage = reset($currentPage);
 
         $currentPage = array_filter($pagesList, function ($page) use ($currentPage) {
-            return $page['page_url'] === $currentPage;
+            return isset($page['page_url']) && $page['page_url'] === $currentPage;
         });
 
         return reset($currentPage);

--- a/includes/class-wp-statistics-pages.php
+++ b/includes/class-wp-statistics-pages.php
@@ -368,7 +368,7 @@ class Pages
                             'title'     => esc_html($term->name),
                             'link'      => (is_wp_error(get_term_link($page_id)) === true ? '' : get_term_link($page_id)),
                             'edit_link' => get_edit_term_link($page_id),
-                            'report'    => Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term->term_taxonomy_id]),
+                            'report'    => Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term->term_id]),
                             'meta'      => array(
                                 'taxonomy'         => $term->taxonomy,
                                 'term_taxonomy_id' => $term->term_taxonomy_id,
@@ -546,7 +546,7 @@ class Pages
 
             $reportUrl = '';
             if (isset($page_info['meta']['term_taxonomy_id'])) {
-                $reportUrl = Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $page_info['meta']['term_taxonomy_id']]);
+                $reportUrl = Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $item->id]);
             } else if (isset($page_info['meta']['author_id'])) {
                 $reportUrl = Menus::admin_url('author-analytics', ['type' => 'single-author', 'author_id' => $page_info['meta']['author_id']]);
             } else if (isset($page_info['meta']['post_type'])) {

--- a/includes/class-wp-statistics-user.php
+++ b/includes/class-wp-statistics-user.php
@@ -198,8 +198,17 @@ class User
         switch ($type) {
             case "manage":
             case "read":
-                return current_user_can(self::ExistCapability(Option::get($list[$cap][0], $list[$cap][1])));
-                break;
+                $capability = Option::get($list[$cap][0], $list[$cap][1]);
+
+                // Honour the configured capability as it is, so grants made on the user
+                // rather than the role are recognised too.
+                if (!empty($capability) && current_user_can($capability)) {
+                    return true;
+                }
+
+                // Fall back to the resolved capability, which degrades to manage_options
+                // when the configured one is not registered on any role.
+                return current_user_can(self::ExistCapability($capability));
             case "both":
                 foreach (array('manage', 'read') as $c) {
                     if (self::Access($c) === true) {
@@ -210,6 +219,36 @@ class User
         }
 
         return false;
+    }
+
+    /**
+     * Check User Access To The WP Statistics Admin Page Being Requested
+     *
+     * Page capabilities can be replaced one page at a time through the
+     * `wp_statistics_admin_menu_list` filter, so a role can be admitted to a single
+     * page without holding the global read or manage capability. Outside plugin pages
+     * this is the plain access check.
+     *
+     * @return bool
+     */
+    public static function hasPageAccess()
+    {
+        if (self::Access() === true) {
+            return true;
+        }
+
+        if (!Menus::in_plugin_page()) {
+            return false;
+        }
+
+        $page = Menus::getCurrentPage();
+
+        // Pages without their own capability are covered by the check above.
+        if (empty($page['cap'])) {
+            return false;
+        }
+
+        return current_user_can($page['cap']);
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -150,7 +150,10 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
-= 14.16.12 - 2026-08-31
+= 14.16.13 - unreleased =
+- **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
+
+= 14.16.12 - 2026-08-31 =
 - **Enhancement:** General security hardening and internal improvements.
 
 = 14.16.11 - 2026-08-22 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wp-statistics.com/donate/
 Tags: analytics, google analytics, insights, stats, site visitors
 Requires at least: 6.6
 Tested up to: 7.1
-Stable tag: 14.16.12
+Stable tag: 14.16.13
 Requires PHP: 7.4
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -150,10 +150,11 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
-= 14.16.13 - unreleased =
-- **Fix:** Unrecognized date period names no longer trigger PHP warnings; the date filter is skipped instead (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
-- **Fix:** Custom roles granted access to a single analytics page now get the full date range picker again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
-- **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.
+= 14.16.13 - 2026-09-05 =
+- **Fix:** Corrected report links in Category Analytics.
+- **Fix:** Date filters no longer trigger PHP warnings when the period name is unrecognized (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
+- **Fix:** Analytics page access and the date range picker now work correctly for custom roles and per-user capabilities (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
+- **Enhancement:** Internal improvements and PHP 8.5 compatibility.
 
 = 14.16.12 - 2026-08-31 =
 - **Enhancement:** General security hardening and internal improvements.

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,10 @@ To ensure the plugin works correctly, please clear your cache because some reque
 Update add-ons DataPlus, Advanced Reporting, and Mini-Chart to the latest version.
 
 == Changelog ==
+= 14.16.13 - unreleased =
+- **Fix:** Custom roles granted access to a single analytics page now get the full date range picker and page data again (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
+- **Fix:** WP Statistics capabilities granted directly to a user, rather than through a role, are now recognised.
+
 = 14.16.12 - 2026-08-31
 - **Enhancement:** General security hardening and internal improvements.
 

--- a/src/Utils/Query.php
+++ b/src/Utils/Query.php
@@ -189,6 +189,9 @@ class Query
     {
         if (empty($date)) return $this;
 
+        $from = '';
+        $to   = '';
+
         if (is_array($date)) {
             $from = isset($date['from']) ? $date['from'] : '';
             $to   = isset($date['to']) ? $date['to'] : '';
@@ -196,8 +199,8 @@ class Query
 
         if (is_string($date)) {
             $date = DateRange::get($date);
-            $from = $date['from'];
-            $to   = $date['to'];
+            $from = isset($date['from']) ? $date['from'] : '';
+            $to   = isset($date['to']) ? $date['to'] : '';
         }
 
         if (!empty($from) && !empty($to)) {

--- a/tests/integration/Test_TrackerDebuggerPhp85.php
+++ b/tests/integration/Test_TrackerDebuggerPhp85.php
@@ -13,7 +13,7 @@ class Test_TrackerDebuggerPhp85 extends WP_UnitTestCase
      */
     public function test_tracker_checks_do_not_emit_deprecations()
     {
-        add_filter('pre_http_request', static function () {
+        $httpRequestFilter = static function () {
             return [
                 'headers'  => [],
                 'body'     => '{"status":true}',
@@ -21,7 +21,8 @@ class Test_TrackerDebuggerPhp85 extends WP_UnitTestCase
                 'cookies'  => [],
                 'filename' => null,
             ];
-        });
+        };
+        add_filter('pre_http_request', $httpRequestFilter);
 
         $previousOptions = Option::getOptions();
         $deprecations    = [];
@@ -41,6 +42,7 @@ class Test_TrackerDebuggerPhp85 extends WP_UnitTestCase
                 (new DebuggerFactory())->getAllProviders();
             }
         } finally {
+            remove_filter('pre_http_request', $httpRequestFilter);
             restore_error_handler();
             Option::save_options($previousOptions);
         }

--- a/tests/integration/Test_TrackerDebuggerPhp85.php
+++ b/tests/integration/Test_TrackerDebuggerPhp85.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace WP_Statistics\Tests\Service\Debugger;
+
+use WP_Statistics\Option;
+use WP_Statistics\Service\Debugger\DebuggerFactory;
+use WP_UnitTestCase;
+
+class Test_TrackerDebuggerPhp85 extends WP_UnitTestCase
+{
+    /**
+     * Ensure the debugger's tracker checks remain free of PHP deprecations.
+     */
+    public function test_tracker_checks_do_not_emit_deprecations()
+    {
+        add_filter('pre_http_request', static function () {
+            return [
+                'headers'  => [],
+                'body'     => '{"status":true}',
+                'response' => ['code' => 200, 'message' => 'OK'],
+                'cookies'  => [],
+                'filename' => null,
+            ];
+        });
+
+        $previousOptions = Option::getOptions();
+        $deprecations    = [];
+
+        set_error_handler(static function ($severity, $message, $file, $line) use (&$deprecations) {
+            if (in_array($severity, [E_DEPRECATED, E_USER_DEPRECATED], true)) {
+                $deprecations[] = sprintf('%s:%d %s', $file, $line, $message);
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            foreach ([false, true] as $bypassAdBlockers) {
+                Option::update('bypass_ad_blockers', $bypassAdBlockers);
+                (new DebuggerFactory())->getAllProviders();
+            }
+        } finally {
+            restore_error_handler();
+            Option::save_options($previousOptions);
+        }
+
+        $this->assertSame([], $deprecations, implode("\n", $deprecations));
+    }
+}

--- a/tests/unit/Test_AdminAccessGuards.php
+++ b/tests/unit/Test_AdminAccessGuards.php
@@ -2,6 +2,7 @@
 
 use WP_Statistics\Service\Admin\Metabox\MetaboxManager;
 use WP_STATISTICS\Admin_Assets;
+use WP_STATISTICS\Menus;
 use WP_STATISTICS\Option;
 use WP_STATISTICS\User;
 
@@ -33,6 +34,9 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
     public function tearDown(): void
     {
+        global $pagenow;
+
+        remove_filter('wp_statistics_admin_menu_list', [$this, 'restrictContentAnalyticsToCustomCap'], 20);
         remove_filter('wp_statistics_metabox_list', [$this, 'recordMetaboxList']);
         remove_action('admin_init', [$this->metaboxManager, 'registerMetaboxes']);
         remove_action('admin_init', [$this->metaboxManager, 'hideDashboardMetaboxes']);
@@ -48,7 +52,10 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
 
         remove_role('wps_manager_only');
         remove_role('wps_reader_only');
+        remove_role('wps_content_analyst');
         wp_set_current_user(0);
+        unset($_REQUEST['page']);
+        $pagenow = 'index.php';
         set_current_screen('front');
 
         parent::tearDown();
@@ -150,6 +157,116 @@ class Test_AdminAccessGuards extends WP_UnitTestCase
         $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
         $this->assertSame(0, $this->metaboxListCalls);
+    }
+
+    public function test_custom_role_admitted_to_a_plugin_page_receives_admin_assets()
+    {
+        global $pagenow;
+
+        add_role(
+            'wps_content_analyst',
+            'WP Statistics Content Analyst',
+            [
+                'read'                       => true,
+                'wps_view_content_analytics' => true,
+            ]
+        );
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        add_filter('wp_statistics_admin_menu_list', [$this, 'restrictContentAnalyticsToCustomCap'], 20);
+        $this->setCurrentUserWithRole('wps_content_analyst');
+
+        $this->assertFalse(User::Access());
+
+        $pagenow          = 'admin.php';
+        $_REQUEST['page'] = Menus::get_page_slug('content-analytics');
+
+        $this->assertTrue(User::hasPageAccess());
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('statistics_page_wps_content-analytics_page');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix . '-daterangepicker', 'enqueued'));
+
+        $localizedData = wp_scripts()->get_data(Admin_Assets::$prefix, 'data');
+        $this->assertIsString($localizedData);
+        $this->assertStringContainsString('"user_date_range"', $localizedData);
+        $this->assertStringContainsString('"from":', $localizedData);
+        $this->assertStringContainsString('"to":', $localizedData);
+    }
+
+    public function test_users_without_the_page_capability_receive_no_assets_on_a_plugin_page_slug()
+    {
+        global $pagenow;
+
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        add_filter('wp_statistics_admin_menu_list', [$this, 'restrictContentAnalyticsToCustomCap'], 20);
+        $this->setCurrentUserWithRole('subscriber');
+
+        $pagenow          = 'admin.php';
+        $_REQUEST['page'] = Menus::get_page_slug('content-analytics');
+
+        $this->assertFalse(User::hasPageAccess());
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('statistics_page_wps_content-analytics_page');
+
+        $this->assertFalse(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertFalse(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    public function test_capability_granted_on_the_user_instead_of_the_role_is_honoured()
+    {
+        $options                      = Option::getOptions();
+        $options['manage_capability'] = 'wps_manage_stats';
+        $options['read_capability']   = 'wps_read_stats';
+        Option::save_options($options);
+
+        $userId = self::factory()->user->create(['role' => 'subscriber']);
+        $user   = get_user_by('id', $userId);
+        $user->add_cap('wps_read_stats');
+        wp_set_current_user($userId);
+
+        // No role carries the capability, so the resolver still degrades to manage_options.
+        $this->assertSame('manage_options', User::ExistCapability('wps_read_stats'));
+
+        $this->assertTrue(User::Access('read'));
+        $this->assertFalse(User::Access('manage'));
+
+        $this->assets->admin_styles();
+        $this->assets->admin_scripts('index.php');
+
+        $this->assertTrue(wp_style_is(Admin_Assets::$prefix, 'enqueued'));
+        $this->assertTrue(wp_script_is(Admin_Assets::$prefix, 'enqueued'));
+    }
+
+    /**
+     * Mimics an add-on that hands a single analytics page its own capability,
+     * which is how Roles and Permissions admits a custom role to one page.
+     */
+    public function restrictContentAnalyticsToCustomCap(array $menus): array
+    {
+        $existing = isset($menus['content_analytics']) ? $menus['content_analytics'] : [];
+
+        $menus['content_analytics'] = array_merge($existing, [
+            'sub'      => 'overview',
+            'title'    => 'Content Analytics',
+            'page_url' => 'content-analytics',
+            'cap'      => 'wps_view_content_analytics',
+        ]);
+
+        return $menus;
     }
 
     private function setCurrentUserWithRole(string $role): void

--- a/tests/unit/Test_Pages.php
+++ b/tests/unit/Test_Pages.php
@@ -1,0 +1,110 @@
+<?php
+
+use WP_Statistics\Service\Database\Managers\TableHandler;
+use WP_Statistics\Service\Database\Schema\Manager;
+use WP_STATISTICS\DB;
+use WP_STATISTICS\Pages;
+
+class Test_Pages extends WP_UnitTestCase
+{
+    private $term;
+    private $pagesTable;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        global $wpdb;
+
+        $this->pagesTable = DB::table('pages');
+        TableHandler::createTable('pages', Manager::getSchemaForTable('pages'));
+        $wpdb->query("DELETE FROM `{$this->pagesTable}`");
+
+        $this->term = $this->createTermWithDifferentTaxonomyId();
+    }
+
+    public function tearDown(): void
+    {
+        global $wpdb;
+
+        $wpdb->query("DELETE FROM `{$this->pagesTable}`");
+
+        parent::tearDown();
+    }
+
+    public function test_get_page_info_uses_term_id_in_category_analytics_url()
+    {
+        $pageInfo = Pages::get_page_info($this->term->term_id, 'category');
+        $query     = $this->getUrlQuery($pageInfo['report']);
+
+        $this->assertSame((string)$this->term->term_id, $query['term_id']);
+    }
+
+    public function test_get_top_uses_term_id_in_category_analytics_url()
+    {
+        global $wpdb;
+
+        $date = current_time('Y-m-d');
+        $wpdb->insert(
+            $this->pagesTable,
+            [
+                'uri'   => get_term_link($this->term->term_id),
+                'type'  => 'category',
+                'date'  => $date,
+                'count' => 1,
+                'id'    => $this->term->term_id,
+            ]
+        );
+
+        $pages = Pages::getTop([
+            'from' => $date,
+            'to'   => $date,
+            'type' => 'category',
+        ]);
+        $query = $this->getUrlQuery($pages[0]['hits_page']);
+
+        $this->assertSame((string)$this->term->term_id, $query['term_id']);
+    }
+
+    private function createTermWithDifferentTaxonomyId()
+    {
+        global $wpdb;
+
+        $termId = self::factory()->term->create([
+            'taxonomy' => 'category',
+            'name'     => 'Category analytics link test ' . wp_generate_uuid4(),
+        ]);
+        $term = get_term($termId, 'category');
+
+        if ($term->term_id === $term->term_taxonomy_id) {
+            $wpdb->insert(
+                $wpdb->term_taxonomy,
+                [
+                    'term_id'     => $term->term_id,
+                    'taxonomy'    => 'post_tag',
+                    'description' => '',
+                    'parent'      => 0,
+                    'count'       => 0,
+                ]
+            );
+            $wpdb->delete($wpdb->term_taxonomy, ['term_taxonomy_id' => $wpdb->insert_id]);
+
+            $termId = self::factory()->term->create([
+                'taxonomy' => 'category',
+                'name'     => 'Category analytics link regression ' . wp_generate_uuid4(),
+            ]);
+            $term = get_term($termId, 'category');
+        }
+
+        $this->assertNotSame($term->term_id, $term->term_taxonomy_id);
+
+        return $term;
+    }
+
+    private function getUrlQuery($url)
+    {
+        parse_str(wp_parse_url($url, PHP_URL_QUERY), $query);
+
+        return $query;
+    }
+}

--- a/tests/unit/Test_Pages.php
+++ b/tests/unit/Test_Pages.php
@@ -10,6 +10,13 @@ class Test_Pages extends WP_UnitTestCase
     private $term;
     private $pagesTable;
 
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        TableHandler::createTable('pages', Manager::getSchemaForTable('pages'));
+    }
+
     public function setUp(): void
     {
         parent::setUp();
@@ -17,7 +24,6 @@ class Test_Pages extends WP_UnitTestCase
         global $wpdb;
 
         $this->pagesTable = DB::table('pages');
-        TableHandler::createTable('pages', Manager::getSchemaForTable('pages'));
         $wpdb->query("DELETE FROM `{$this->pagesTable}`");
 
         $this->term = $this->createTermWithDifferentTaxonomyId();

--- a/wp-statistics.php
+++ b/wp-statistics.php
@@ -4,7 +4,7 @@
  * Plugin URI: https://wp-statistics.com/
  * GitHub Plugin URI: https://github.com/wp-statistics/wp-statistics
  * Description: Get website traffic insights with GDPR/CCPA compliant, privacy-friendly analytics. Includes visitor data, stunning graphs, and no data sharing.
- * Version: 14.16.12
+ * Version: 14.16.13
  * Author: VeronaLabs
  * Author URI: https://veronalabs.com/
  * Text Domain: wp-statistics
@@ -22,7 +22,7 @@ if (!defined('ABSPATH')) exit;
 require_once __DIR__ . '/includes/defines.php';
 
 # Set another useful plugin define.
-define('WP_STATISTICS_VERSION', '14.16.12');
+define('WP_STATISTICS_VERSION', '14.16.13');
 
 # Load Plugin
 if (!class_exists('WP_Statistics')) {


### PR DESCRIPTION
Release branch for 14.16.13 (2026-09-05).

## Changes
- **Fix:** Corrected report links in Category Analytics (#1135).
- **Fix:** Date filters no longer trigger PHP warnings when the period name is unrecognized (#1130).
- **Fix:** Analytics page access and the date range picker now work correctly for custom roles and per-user capabilities (#1126).
- **Enhancement:** Internal improvements and PHP 8.5 compatibility (#1133).

The 14.16.13 changelog entry in `CHANGELOG.md` and `readme.txt` has been condensed and dated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Category Analytics report links.
  - Prevented PHP warnings from unrecognized or incomplete date-filter ranges.
  - Improved Analytics page access and date-range picker support for custom roles and individual capabilities.
  - Prevented errors when menu entries lack page links.

- **Compatibility**
  - Added PHP 8.5 support and expanded automated testing.

- **Documentation**
  - Updated the changelog and plugin version to 14.16.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->