### PR TITLE
Fix term archive View links in Top Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 14.16.13 - 2026-09-05
 - **Fix:** Corrected report links in Category Analytics.
+- **Fix:** Top Pages "View" links now open the correct term archive for categories, tags, and taxonomies (issue [#1138](https://github.com/wp-statistics/wp-statistics/issues/1138)).
 - **Fix:** Date filters no longer trigger PHP warnings when the period name is unrecognized (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).
 - **Fix:** Analytics page access and the date range picker now work correctly for custom roles and per-user capabilities (issue [#1126](https://github.com/wp-statistics/wp-statistics/issues/1126)).
 - **Enhancement:** Internal improvements and PHP 8.5 compatibility.

--- a/includes/class-wp-statistics-pages.php
+++ b/includes/class-wp-statistics-pages.php
@@ -366,7 +366,7 @@ class Pages
                     if (!is_wp_error($term) and $term !== null) {
                         $arg = array(
                             'title'     => esc_html($term->name),
-                            'link'      => (is_wp_error(get_term_link($page_id)) === true ? '' : get_term_link($page_id)),
+                            'link'      => (is_wp_error(get_term_link($term)) === true ? '' : get_term_link($term)),
                             'edit_link' => get_edit_term_link($page_id),
                             'report'    => Menus::admin_url('category-analytics', ['type' => 'single', 'term_id' => $term->term_id]),
                             'meta'      => array(

--- a/tests/unit/Test_Pages.php
+++ b/tests/unit/Test_Pages.php
@@ -46,6 +46,13 @@ class Test_Pages extends WP_UnitTestCase
         $this->assertSame((string)$this->term->term_id, $query['term_id']);
     }
 
+    public function test_get_page_info_uses_term_archive_url_for_numeric_string_id()
+    {
+        $pageInfo = Pages::get_page_info((string)$this->term->term_id, 'category');
+
+        $this->assertSame(get_term_link($this->term), $pageInfo['link']);
+    }
+
     public function test_get_top_uses_term_id_in_category_analytics_url()
     {
         global $wpdb;


### PR DESCRIPTION
## Summary
- resolve term archive links from the `WP_Term` object already loaded by `Pages::get_page_info()`
- add regression coverage for numeric-string term IDs returned from database results
- document the fix in the changelog

## Why
WordPress treats a numeric string passed to `get_term_link()` as a slug, so Top Pages rows for categories, tags, and custom taxonomies received an empty frontend URL. Passing the resolved term object preserves the correct taxonomy and term ID.

## Test plan
- `phpunit tests/unit/Test_Pages.php` — OK (3 tests, 6 assertions)
- `php -l includes/class-wp-statistics-pages.php`
- `php -l tests/unit/Test_Pages.php`

## Manual verification
1. Make a category, tag, or custom taxonomy archive appear in the dashboard Top Pages metabox.
2. Click its **View** link.
3. Confirm the correct frontend term archive opens in a new tab.

Closes #1138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Top Pages “View” links so category, tag, and taxonomy entries open the correct term archive pages.
  - Added coverage to verify archive links work when term IDs are provided as numeric strings.

- **Documentation**
  - Added a changelog entry describing the corrected archive links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->