### PR TITLE
Use term IDs for taxonomy views and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+14.16.14 - unreleased
+- **Fix:** Corrected taxonomy archive view attribution and cleanup when term and taxonomy IDs differ (issue [#1139](https://github.com/wp-statistics/wp-statistics/issues/1139)).
+
 14.16.13 - 2026-09-05
 - **Fix:** Corrected report links in Category Analytics.
 - **Fix:** Date filters no longer trigger PHP warnings when the period name is unrecognized (issue [#1130](https://github.com/wp-statistics/wp-statistics/issues/1130)).

--- a/src/Models/TaxonomyModel.php
+++ b/src/Models/TaxonomyModel.php
@@ -58,7 +58,7 @@ class TaxonomyModel extends BaseModel
             ->join('terms', ['term_taxonomy.term_id', 'terms.term_id'])
             ->join('term_relationships', ['term_relationships.term_taxonomy_id', 'term_taxonomy.term_taxonomy_id'], [], 'LEFT')
             ->join('posts', ['posts.ID', 'term_relationships.object_id'], [['posts.post_type', 'IN', $args['post_type']], ['posts.post_status', '=', 'publish']], 'LEFT')
-            ->joinQuery($categoryViewsQuery, ['category.id', 'term_taxonomy.term_taxonomy_id'], 'category', 'LEFT')
+            ->joinQuery($categoryViewsQuery, ['category.id', 'term_taxonomy.term_id'], 'category', 'LEFT')
             ->where('term_taxonomy.taxonomy', 'IN', $args['taxonomy'])
             ->where('posts.post_author', '=', $args['author_id'])
             ->groupBy(['taxonomy', 'terms.term_id', 'terms.name'])

--- a/src/Service/Admin/Posts/PostsManager.php
+++ b/src/Service/Admin/Posts/PostsManager.php
@@ -158,7 +158,7 @@ class PostsManager
         $wpdb->query(
             $wpdb->prepare(
                 "DELETE FROM `" . DB::table('pages') . "` WHERE `id` = %d AND (`type` = 'category' OR `type` = 'post_tag' OR `type` = %s);",
-                $ttId,
+                $term,
                 $taxSlug
             )
         );

--- a/tests/unit/Test_Pages.php
+++ b/tests/unit/Test_Pages.php
@@ -1,6 +1,8 @@
 <?php
 
 use WP_Statistics\Service\Database\Managers\TableHandler;
+use WP_Statistics\Models\TaxonomyModel;
+use WP_Statistics\Service\Admin\Posts\PostsManager;
 use WP_Statistics\Service\Database\Schema\Manager;
 use WP_STATISTICS\DB;
 use WP_STATISTICS\Pages;
@@ -70,6 +72,67 @@ class Test_Pages extends WP_UnitTestCase
         $query = $this->getUrlQuery($pages[0]['hits_page']);
 
         $this->assertSame((string)$this->term->term_id, $query['term_id']);
+    }
+
+    public function test_taxonomy_data_uses_term_id_for_archive_views()
+    {
+        global $wpdb;
+
+        $date   = current_time('Y-m-d');
+        $postId = self::factory()->post->create(['post_status' => 'publish']);
+        wp_set_post_terms($postId, [$this->term->term_id], 'category');
+
+        $wpdb->insert(
+            $this->pagesTable,
+            [
+                'uri'   => get_term_link($this->term->term_id),
+                'type'  => 'category',
+                'date'  => $date,
+                'count' => 7,
+                'id'    => $this->term->term_id,
+            ]
+        );
+
+        $taxonomies = (new TaxonomyModel())->getTaxonomiesData([
+            'post_type'         => ['post'],
+            'taxonomy'          => ['category'],
+            'resource_type'     => ['category'],
+            'date'              => ['from' => $date, 'to' => $date],
+            'count_total_posts' => true,
+            'per_page'          => -1,
+        ]);
+        $category = array_values(array_filter($taxonomies['category'], function ($item) {
+            return (int)$item['term_id'] === (int)$this->term->term_id;
+        }));
+
+        $this->assertSame(7, (int)$category[0]['views']);
+    }
+
+    public function test_delete_term_hits_uses_term_id_and_preserves_taxonomy_id_collision()
+    {
+        global $wpdb;
+
+        $date = current_time('Y-m-d');
+        foreach ([$this->term->term_id, $this->term->term_taxonomy_id] as $id) {
+            $wpdb->insert(
+                $this->pagesTable,
+                [
+                    'uri'   => 'https://example.org/term-' . $id,
+                    'type'  => 'category',
+                    'date'  => $date,
+                    'count' => 1,
+                    'id'    => $id,
+                ]
+            );
+        }
+
+        PostsManager::deleteTermHits($this->term->term_id, $this->term->term_taxonomy_id, 'category');
+
+        $termRows = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `{$this->pagesTable}` WHERE `id` = %d", $this->term->term_id));
+        $collisionRows = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM `{$this->pagesTable}` WHERE `id` = %d", $this->term->term_taxonomy_id));
+
+        $this->assertSame('0', $termRows);
+        $this->assertSame('1', $collisionRows);
     }
 
     private function createTermWithDifferentTaxonomyId()


### PR DESCRIPTION
### Describe your changes
- Join taxonomy archive views to `term_taxonomy.term_id`, matching the ID stored in `wp_statistics_pages.id`.
- Delete term archive statistics using the WordPress term ID instead of the term-taxonomy ID.
- Add regression coverage where `term_id` and `term_taxonomy_id` intentionally differ.
- Document the fix in the changelog.

This restores the correct archive view count and prevents term deletion from orphaning the intended statistics row or deleting a colliding term's row.

### Tests
- `phpunit --testdox tests/unit/Test_Pages.php` — **OK (4 tests, 9 assertions)**
- `php -l src/Models/TaxonomyModel.php`
- `php -l src/Service/Admin/Posts/PostsManager.php`
- `php -l tests/unit/Test_Pages.php`

Impacted area: taxonomy view attribution and term-statistics cleanup. Tracking and post/page cleanup are unchanged.

#### Checklist
- [x] I executed the code after my changes and verified the behavior
- [x] I tested related queries and considered their impact on other parts
- [x] I verified tracker functionality (filters, privacy, and data recording), if affected — not affected
- [x] I tested impacted add-ons, if any — none affected
- [x] I documented what areas might be impacted by this change

### Type of change
- [x] Fix - Fixes an existing bug

Closes #1139
